### PR TITLE
Устранены найденные утечки памяти

### DIFF
--- a/src/libraries/GlobalParameters.cpp
+++ b/src/libraries/GlobalParameters.cpp
@@ -343,7 +343,7 @@ bool GlobalParameters::isMytetraIniConfig(QString fileName)
    qDebug() << "Config directory name " << dirName;
 
    // Открывается хранилище настроек
-   QSettings *conf=new QSettings(fileName, QSettings::IniFormat);
+   QSettings *conf=new QSettings(fileName, QSettings::IniFormat, this);
    // conf->setPath(QSettings::IniFormat, QSettings::UserScope, dirName);
    // conf->setPath(QSettings::IniFormat, QSettings::SystemScope, dirName);
 

--- a/src/libraries/wyedit/EditorFindDialog.cpp
+++ b/src/libraries/wyedit/EditorFindDialog.cpp
@@ -18,7 +18,8 @@ EditorFindDialog::EditorFindDialog(QWidget *parent) : QDialog(parent)
  setup_signals();
  assembly();
 
- showEvent(new QShowEvent());
+ QShowEvent event;
+ showEvent(&event);
 }
 
 


### PR DESCRIPTION
Добавление this в конструктор QSettings позволит освободить память в деструкторе GlobalParameters.
В конструкторе EditorFindDialog никто не отвечал за высвобождение памяти из-под динамически созданного QShowEvent.