### PR TITLE
Устранено ошибочное поведение при выборе папок базы и мусора + чистка кода

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -205,21 +205,6 @@ void insertActionAsButton(QToolBar *tools_line, QAction *action)
   qobject_cast<QToolButton*>(tools_line->widgetForAction(action))->setAutoRaise(false);
 }
 
-
-int imax(int x1, int x2)
-{
-  if(x1>x2)return x1;
-  else return x2;
-}
-
-
-int imin(int x1, int x2)
-{
-  if(x1<x2)return x1;
-  else return x2;
-}
-
-
 void smartPrintDebugMessage(QString msg)
 {
  if(globalParameters.getTargetOs()=="any" ||

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -266,6 +266,11 @@ void myMessageOutput(QtMsgType type, const QMessageLogContext &context, const QS
    case QtFatalMsg:
        smartPrintDebugMessage("[FTERR] "+msgText+"\n");
        abort();
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 5, 0))
+   case QtInfoMsg:
+       smartPrintDebugMessage("[INF] "+msgText+"\n");
+       break;
+#endif
  }
 
  // #endif

--- a/src/main.h
+++ b/src/main.h
@@ -61,8 +61,6 @@ QString xmlNodeToString(QDomNode xmlData);
 void print_object_tree(void);
 bool compare_QStringList_len(const QStringList &list1, const QStringList &list2);
 void insertActionAsButton(QToolBar *tools_line, QAction *action);
-int imax(int x1, int x2);
-int imin(int x1, int x2);
 void myMessageOutput(QtMsgType type, const char *msg);
 QStringList text_delimiter_decompose(QString text);
 QString get_unical_id(void);

--- a/src/views/appConfigWindow/AppConfigPage_Main.cpp
+++ b/src/views/appConfigWindow/AppConfigPage_Main.cpp
@@ -219,28 +219,26 @@ void AppConfigPage_Main::assembly(void)
 // Действия при нажатии кнопки выбора директории данных
 void AppConfigPage_Main::open_tetradir_select_dialog(void)
 {
- QFileDialog tetradirSelectDialog(this);
- tetradirSelectDialog.setFileMode(QFileDialog::Directory);
- tetradirSelectDialog.setWindowTitle(tr("Select data directory"));
- tetradirSelectDialog.setDirectory(tetradirInput->text());
- 
- tetradirSelectDialog.exec();
- 
- tetradirInput->setText(tetradirSelectDialog.directory().absolutePath());
+ const QString &title = tr("Select data directory");
+ const QString &oldDirectory = tetradirInput->text();
+ const QString &newDirectory = QFileDialog::getExistingDirectory(this, title, oldDirectory);
+
+ if (!newDirectory.isEmpty()){
+   tetradirInput->setText(newDirectory);
+ }
 }
 
 
 // Действия при нажатии кнопки выбора директории корзины
 void AppConfigPage_Main::open_trashdir_select_dialog(void)
 {
- QFileDialog trashdirSelectDialog(this);
- trashdirSelectDialog.setFileMode(QFileDialog::Directory);
- trashdirSelectDialog.setWindowTitle(tr("Select trash directory"));
- trashdirSelectDialog.setDirectory(trashdirInput->text());
- 
- trashdirSelectDialog.exec();
- 
- trashdirInput->setText(trashdirSelectDialog.directory().absolutePath());
+ const QString &title = tr("Select trash directory");
+ const QString &oldDirectory = trashdirInput->text();
+ const QString &newDirectory = QFileDialog::getExistingDirectory(this, title, oldDirectory);
+
+ if (!newDirectory.isEmpty()){
+   trashdirInput->setText(newDirectory);
+ }
 }
 
 

--- a/src/views/findInBaseScreen/FindScreen.cpp
+++ b/src/views/findInBaseScreen/FindScreen.cpp
@@ -158,7 +158,7 @@ void FindScreen::setupCloseButton(void)
   {
     int w=closeButton->geometry().width();
     int h=closeButton->geometry().height();
-    int x=imin(w,h)/2;
+    int x=qMin(w,h)/2;
     closeButton->setSizePolicy(QSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed, QSizePolicy::ToolButton));
     closeButton->setMinimumSize(x,x);
     closeButton->setMaximumSize(x,x);

--- a/src/views/record/InfoFieldEnter.cpp
+++ b/src/views/record/InfoFieldEnter.cpp
@@ -51,7 +51,7 @@ void InfoFieldEnter::setup_ui(void)
  expandInfo->setVisible(true);
  int w=expandInfo->geometry().width();
  int h=expandInfo->geometry().height();
- int x=imin(w,h)/2;
+ int x=qMin(w,h)/2;
  expandInfo->setSizePolicy(QSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed, QSizePolicy::ToolButton));
  expandInfo->setMinimumSize(x,x);
  expandInfo->setMaximumSize(x,x);


### PR DESCRIPTION
При старте программы мы имеем в путях ./data и ./trash. Если запустить
стандартный диалог выбора существующей папки и после этого нажать
отмену, то путь в QTextEdit изменялся.