### PR TITLE
В qtSingleApplication5/qtlocalpeer.cpp добавлен include <QDataStream>

### DIFF
--- a/src/libraries/qtSingleApplication5/qtlocalpeer.cpp
+++ b/src/libraries/qtSingleApplication5/qtlocalpeer.cpp
@@ -39,6 +39,7 @@
 
 #include "qtlocalpeer.h"
 #include <QCoreApplication>
+#include <QDataStream>
 #include <QTime>
 
 #if defined(Q_OS_WIN)


### PR DESCRIPTION
Его отсутствие вызывало ошибку компиляции в Qt 5.5.1