### PR TITLE
Кнопка показа непечатаемых символов стала зажимаемой

### DIFF
--- a/src/libraries/wyedit/Editor.cpp
+++ b/src/libraries/wyedit/Editor.cpp
@@ -377,8 +377,8 @@ void Editor::setupSignals(void)
   connect(editorToolBarAssistant->settings, SIGNAL(clicked()),
           this,                             SLOT  (onSettingsClicked()),
           Qt::DirectConnection);
-  connect(editorToolBarAssistant->showFormatting, SIGNAL(clicked()),
-          this,                                   SLOT  (onShowformattingClicked()),
+  connect(editorToolBarAssistant->showFormatting, SIGNAL(toggled(bool)),
+          this,                                   SLOT  (setNonprintableCharactersVisible(bool)),
           Qt::DirectConnection);
 
 
@@ -1184,22 +1184,10 @@ void Editor::onSettingsClicked(void)
   dialog.show();
 }
 
-
-// Действия при нажатии кнопки отображения символов редактирования
-void Editor::onShowformattingClicked(void)
+void Editor::setNonprintableCharactersVisible(bool ok)
 {
-  if(textArea->get_showformatting()==false)
-  {
-    textArea->set_showformatting(true);
-    editorToolBarAssistant->setShowFormattingButtonHiglight(true);
-  }
-  else
-  {
-    textArea->set_showformatting(false);
-    editorToolBarAssistant->setShowFormattingButtonHiglight(false);
-  }
+    textArea->set_showformatting(ok);
 }
-
 
 void Editor::onExpandEditAreaClicked(void)
 {

--- a/src/libraries/wyedit/Editor.h
+++ b/src/libraries/wyedit/Editor.h
@@ -180,7 +180,7 @@ private slots:
  void onShowhtmlClicked(void);
  void onFindtextClicked(void);
  void onSettingsClicked(void);
- void onShowformattingClicked(void);
+ void setNonprintableCharactersVisible(bool);
 
  void onExpandEditAreaClicked(void);
  void onSaveClicked(void);

--- a/src/libraries/wyedit/EditorToolBar.cpp
+++ b/src/libraries/wyedit/EditorToolBar.cpp
@@ -32,7 +32,6 @@ EditorToolBar::~EditorToolBar()
   delete reference;
   delete showHtml;
   delete findText;
-  delete showFormatting;
   delete createTable;
   delete tableRemoveRow;
   delete tableRemoveCol;
@@ -258,6 +257,7 @@ void EditorToolBar::setupButtons(void)
 
   // Кнопка включения отображения символов фарматирования
   showFormatting = new QToolButton(this);
+  showFormatting->setCheckable(true);
   showFormatting->setStatusTip(tr("Show special chars"));
   showFormatting->setIcon(QIcon(":/resource/pic/edit_showformatting.svg"));
   showFormatting->setObjectName("editor_tb_showformatting");

--- a/src/libraries/wyedit/EditorToolBarAssistant.cpp
+++ b/src/libraries/wyedit/EditorToolBarAssistant.cpp
@@ -289,21 +289,6 @@ void EditorToolBarAssistant::switchExpandToolsLines(int flag)
   emit updateIndentSliderGeometry();
 }
 
-
-// Включение/выключение подсветки кнопки отображения символов форматирования
-void EditorToolBarAssistant::setShowFormattingButtonHiglight(bool active)
-{
-  QPalette palActive, palInactive;
-  palActive.setColor(QPalette::Normal, QPalette::Button, buttonsSelectColor);
-  palActive.setColor(QPalette::Normal, QPalette::Window, buttonsSelectColor);
-
-  if(active)
-    showFormatting->setPalette(palActive);
-  else
-    showFormatting->setPalette(palInactive);
-}
-
-
 bool EditorToolBarAssistant::isKeyForToolLineUpdate(QKeyEvent *event)
 {
   if(event->modifiers().testFlag(Qt::ControlModifier) ||


### PR DESCRIPTION
Нет необходимости использовать палитры для того, чтобы обозначать
включённость кнопки. Это ответственность Qt.