### PR TITLE
Добавлена возможность зажимать кнопки выравнивания

### DIFF
--- a/src/libraries/wyedit/Editor.cpp
+++ b/src/libraries/wyedit/Editor.cpp
@@ -16,6 +16,7 @@
 #include <QFileDialog>
 #include <QScrollBar>
 #include <QColor>
+#include <QButtonGroup>
 
 #include "Editor.h"
 #include "EditorConfig.h"
@@ -320,19 +321,9 @@ void Editor::setupSignals(void)
           indentSliderAssistant, SLOT  (updateToActualFormat()),
           Qt::DirectConnection);
 
-  connect(editorToolBarAssistant->alignLeft, SIGNAL(clicked()),
-          placementFormatter,                SLOT  (onAlignleftClicked()),
+  connect(editorToolBarAssistant->alignButtons, SIGNAL(buttonClicked(int)),
+          placementFormatter,                   SLOT(setTextAlign(int)),
           Qt::DirectConnection);
-  connect(editorToolBarAssistant->alignCenter, SIGNAL(clicked()),
-          placementFormatter,                  SLOT  (onAligncenterClicked()),
-          Qt::DirectConnection);
-  connect(editorToolBarAssistant->alignRight, SIGNAL(clicked()),
-          placementFormatter,                 SLOT  (onAlignrightClicked()),
-          Qt::DirectConnection);
-  connect(editorToolBarAssistant->alignWidth, SIGNAL(clicked()),
-          placementFormatter,                 SLOT  (onAlignwidthClicked()),
-          Qt::DirectConnection);
-
 
   connect(editorToolBarAssistant->numericList, SIGNAL(clicked()),
           listFormatter,                       SLOT  (onNumericlistClicked()),

--- a/src/libraries/wyedit/EditorToolBar.cpp
+++ b/src/libraries/wyedit/EditorToolBar.cpp
@@ -1,3 +1,4 @@
+#include <QButtonGroup>
 #include "main.h"
 #include "EditorToolBar.h"
 #include "Editor.h"
@@ -21,10 +22,6 @@ EditorToolBar::~EditorToolBar()
   delete dotList;
   delete indentPlus;
   delete indentMinus;
-  delete alignLeft;
-  delete alignCenter;
-  delete alignRight;
-  delete alignWidth;
   delete settings;
   delete fontSelect;
   delete fontSize;
@@ -170,6 +167,7 @@ void EditorToolBar::setupButtons(void)
 
   // Кнопка выравнивания по левому краю
   alignLeft = new QToolButton(this);
+  alignLeft->setCheckable(true);
   alignLeft->setShortcut(QKeySequence(tr("Ctrl+L")));
   alignLeft->setStatusTip(tr("Align left (Ctrl+L)"));
   alignLeft->setIcon(QIcon(":/resource/pic/edit_alignleft.svg"));
@@ -177,6 +175,7 @@ void EditorToolBar::setupButtons(void)
 
   // Кнопка выравнивания по центру
   alignCenter = new QToolButton(this);
+  alignCenter->setCheckable(true);
   alignCenter->setShortcut(QKeySequence(tr("Ctrl+E")));
   alignCenter->setStatusTip(tr("Align center (Ctrl+E)"));
   alignCenter->setIcon(QIcon(":/resource/pic/edit_aligncenter.svg"));
@@ -184,6 +183,7 @@ void EditorToolBar::setupButtons(void)
 
   // Кнопка выравнивания по правому краю
   alignRight = new QToolButton(this);
+  alignRight->setCheckable(true);
   alignRight->setShortcut(QKeySequence(tr("Ctrl+R")));
   alignRight->setStatusTip(tr("Align right (Ctrl+R)"));
   alignRight->setIcon(QIcon(":/resource/pic/edit_alignright.svg"));
@@ -191,11 +191,18 @@ void EditorToolBar::setupButtons(void)
 
   // Кнопка выравнивания по ширине
   alignWidth = new QToolButton(this);
+  alignWidth->setCheckable(true);
   alignWidth->setShortcut(QKeySequence(tr("Ctrl+J")));
   alignWidth->setStatusTip(tr("Align width (Ctrl+J)"));
   alignWidth->setIcon(QIcon(":/resource/pic/edit_alignwidth.svg"));
   alignWidth->setObjectName("editor_tb_alignwidth");
 
+  // Объединение кнопок выравнивания в группу
+  alignButtons = new QButtonGroup(this);
+  alignButtons->addButton(alignLeft, Qt::AlignLeft);
+  alignButtons->addButton(alignCenter, Qt::AlignHCenter);
+  alignButtons->addButton(alignRight, Qt::AlignRight);
+  alignButtons->addButton(alignWidth, Qt::AlignJustify);
 
   // Выбор шрифта
   fontSelect = new QFontComboBox(this);

--- a/src/libraries/wyedit/EditorToolBar.h
+++ b/src/libraries/wyedit/EditorToolBar.h
@@ -14,6 +14,7 @@
 #define MINIMUM_ALLOWED_FONT_SIZE 5
 #define MAXIMUM_ALLOWED_FONT_SIZE 100
 
+class QButtonGroup;
 
 class EditorToolBar : public QWidget
 {
@@ -38,6 +39,7 @@ public:
   QToolButton   *indentPlus=NULL;
   QToolButton   *indentMinus=NULL;
 
+  QButtonGroup  *alignButtons=NULL;
   QToolButton   *alignLeft=NULL;
   QToolButton   *alignCenter=NULL;
   QToolButton   *alignRight=NULL;

--- a/src/libraries/wyedit/EditorToolBarAssistant.cpp
+++ b/src/libraries/wyedit/EditorToolBarAssistant.cpp
@@ -1,4 +1,5 @@
 #include <QColor>
+#include <QButtonGroup>
 
 #include "main.h"
 #include "EditorToolBarAssistant.h"
@@ -150,28 +151,20 @@ void EditorToolBarAssistant::onChangeFontcolor(QColor color)
 }
 
 
-// Слот обновления подсветки кнопок выравнивания текста
-// Если параметр activate=false, все кнопки будут выставлены в неактивные
-// Если параметр activate=true, будет подсвечена кнопка, соответсвующая текущему форматированию
-void EditorToolBarAssistant::onUpdateAlignButtonHiglight(bool activate)
+// Метод для обновления положения кнопок выравнивания текста (зажата/отжата)
+void EditorToolBarAssistant::updateAlignButtonSelection()
 {
   // TRACELOG
 
-  QPalette palActive, palInactive;
-  palActive.setColor(QPalette::Normal, QPalette::Button, buttonsSelectColor);
-  palActive.setColor(QPalette::Normal, QPalette::Window, buttonsSelectColor);
-
-  alignLeft->setPalette(palInactive);
-  alignCenter->setPalette(palInactive);
-  alignRight->setPalette(palInactive);
-  alignWidth->setPalette(palInactive);
-
-  if(activate==false)return;
-
-  if(textArea->alignment()==Qt::AlignLeft)         alignLeft->setPalette(palActive);
-  else if(textArea->alignment()==Qt::AlignHCenter) alignCenter->setPalette(palActive);
-  else if(textArea->alignment()==Qt::AlignRight)   alignRight->setPalette(palActive);
-  else if(textArea->alignment()==Qt::AlignJustify) alignWidth->setPalette(palActive);
+  const int aligment = textArea->alignment();
+  foreach(QAbstractButton *button, alignButtons->buttons())
+  {
+      if (alignButtons->id(button) == aligment)
+      {
+          button->setChecked(true);
+          break;
+      }
+  }
 }
 
 
@@ -237,7 +230,7 @@ void EditorToolBarAssistant::updateToActualFormat(void)
   onUpdateOutlineButtonHiglight();
 
   // Обновляются кнопки выравнивания
-  onUpdateAlignButtonHiglight(true);
+  updateAlignButtonSelection();
 }
 
 

--- a/src/libraries/wyedit/EditorToolBarAssistant.h
+++ b/src/libraries/wyedit/EditorToolBarAssistant.h
@@ -53,13 +53,15 @@ signals:
 public slots:
 
   void onExpandToolsLinesClicked(void);
-  void onUpdateAlignButtonHiglight(bool activate);
   void onUpdateOutlineButtonHiglight(void);
   void onChangeFontselectOnDisplay(QString fontName);
   void onChangeFontsizeOnDisplay(int n);
   void onChangeFontFamily(QString fontFamily);
   void onChangeFontPointSize(int n);
   void onChangeFontcolor(QColor color);
+
+private:
+  void updateAlignButtonSelection();
 
 protected:
 

--- a/src/libraries/wyedit/formatters/PlacementFormatter.cpp
+++ b/src/libraries/wyedit/formatters/PlacementFormatter.cpp
@@ -58,34 +58,11 @@ void PlacementFormatter::onIndentminusClicked(void)
   emit updateIndentsliderToActualFormat();
 }
 
-
-// Форматирование по левому краю
-void PlacementFormatter::onAlignleftClicked(void)
+// Задание типа выравнивания
+void PlacementFormatter::setTextAlign(int align)
 {
-  alignText(Qt::AlignLeft);
+    alignText(static_cast<Qt::AlignmentFlag>(align));
 }
-
-
-// Форматирование по центру
-void PlacementFormatter::onAligncenterClicked(void)
-{
-  alignText(Qt::AlignHCenter);
-}
-
-
-// Форматирование по правому краю
-void PlacementFormatter::onAlignrightClicked(void)
-{
-  alignText(Qt::AlignRight);
-}
-
-
-// Форматирование по ширине
-void PlacementFormatter::onAlignwidthClicked(void)
-{
-  alignText(Qt::AlignJustify);
-}
-
 
 // Выравнивание текста, вспомогательный метод
 void PlacementFormatter::alignText(Qt::AlignmentFlag mode)

--- a/src/libraries/wyedit/formatters/PlacementFormatter.h
+++ b/src/libraries/wyedit/formatters/PlacementFormatter.h
@@ -24,10 +24,7 @@ public slots:
   void onIndentplusClicked(void);
   void onIndentminusClicked(void);
 
-  void onAlignleftClicked(void);
-  void onAligncenterClicked(void);
-  void onAlignrightClicked(void);
-  void onAlignwidthClicked(void);
+  void setTextAlign(int align);
 
 protected:
 


### PR DESCRIPTION
Вместо изменения их палитры

Убраны излишние высвобождения памяти.
При определении new QToolButton(this) нет смысла освобождать память
вручную в деструкторе this. За нас это сделает Qt.
Добавлено объединение кнопок выравнивания в группу
Кнопкам выравнивания дано свойство зажатия
Слот обновления палитры для кнопок выравнивания заменён методом зажатия
кнопки в группе
Ответственность за выравнивание текста перенесена с кнопок на группу
кнопок (QButtonGroup)
