### PR TITLE
Исправлена ошибка при добавлении записи при отсутствии папки base

### DIFF
--- a/src/models/recordTable/Record.cpp
+++ b/src/models/recordTable/Record.cpp
@@ -881,7 +881,7 @@ void Record::checkAndFillFileDir(QString &iDirName, QString &iFileName)
   {
    // Создается новая директория в директории base
    QDir directory(mytetraConfig.get_tetradir()+"/base");
-   bool result=directory.mkdir( getShortDirName() );
+   bool result=directory.mkpath( getShortDirName() );
 
    if(!result)
      criticalError("Record::checkAndFillFileDir() : Can't create directory '"+getShortDirName()+"'");


### PR DESCRIPTION
Пользователь мог удалить папку base самостоятельно, либо во время
синхронизации и при попытке добавления в пустую базу первой записи
возникала ошибка создания папки под эту запись.