### PR TITLE
Fix potential memory leak.

### DIFF
--- a/src/libraries/crypt/Pbkdf2Qt.cpp
+++ b/src/libraries/crypt/Pbkdf2Qt.cpp
@@ -170,7 +170,11 @@ QByteArray Pbkdf2Qt::Pbkdf2(QByteArray pass,
                                        rounds);
 
  if(calculate_result==-1)
+ {
+  memset(key, 0, key_len);
+  free(key);
   return QByteArray();
+ }
 
  QByteArray result(key, key_len);
 


### PR DESCRIPTION
Освобождение памяти при потенциальном возврате из функции.
Стоило бы переписать реализацию класса без использования выделения памяти в стиле С и без использования raw С массивов/указателей. Но это потянет на мини-рефакторинг. Без заведомого одобрямса от xintrea, подобные телодвижения - пустая трата времени и сил. Ибо улетит коммит в трубу(по крайней мере в этой репе).
Другой вариант (без такого рефакторинга) - RAII