### PR TITLE
Изменил поведение при клике на иконку в трее

### DIFF
--- a/src/views/mainWindow/MainWindow.cpp
+++ b/src/views/mainWindow/MainWindow.cpp
@@ -905,7 +905,7 @@ void MainWindow::setupIconActions(void)
 void MainWindow::showWindow()
 {
   activateWindow();
-  showNormal();
+  show();
   raise();
 }
 

--- a/src/views/mainWindow/MainWindow.cpp
+++ b/src/views/mainWindow/MainWindow.cpp
@@ -909,6 +909,28 @@ void MainWindow::showWindow()
   raise();
 }
 
+void MainWindow::showWindowNormal()
+{
+  activateWindow();
+  showNormal();
+  raise();
+}
+
+void MainWindow::activate() {
+//	bool wasHidden = !isVisible();
+	setWindowState(windowState() & ~Qt::WindowMinimized);
+	setVisible(true);
+	activateWindow();
+//	if (wasHidden) {
+//			show();
+//	}
+}
+
+bool MainWindow::isActive() const {
+	return isActiveWindow() && isVisible() && !(windowState() & Qt::WindowMinimized);
+}
+
+
 
 void MainWindow::createTrayIcon(void)
 {
@@ -947,43 +969,52 @@ void MainWindow::iconActivated(QSystemTrayIcon::ActivationReason reason)
   switch (reason)
   {
     case QSystemTrayIcon::Trigger:
-    case QSystemTrayIcon::DoubleClick:
       // Если окно видно
       if(isVisible())
       {
-        // Если окно неактивно, значит активно другое (и возможно оно перекрывает окно MyTetra)
-        // Не работает в Windows, в Linux не проверял
-        // Причина неработоспособности - при клике на иконку, окно MyTera всегда становится неактивным (т.к. активен систрей)
-        // И условие срабатывает всегда. Доделать или отказаться
-        // if(QGuiApplication::applicationState() == Qt::ApplicationInactive)
-        // {
-        //   activateWindow();
-        //   return;
-        // }
-
-        if(isMinimized())
-        {
-          qDebug() << "If visible and minimized";
-          showWindow();
-          return;
+        if(!isActive()){
+          qDebug() << "If visible and not active";
+          activate();
         }
-        else
-        {
-          qDebug() << "Hide";
-          hide();
-          return;
-        }
+        //при клике на иконку, окно MyTera всегда становится неактивным (т.к. активен систрей)   
+//        else
+//        {
+//          qDebug() << "If visible and active then Hide";
+//          hide();
+//        }
       }
       else
       {
         qDebug() << "If not visible";
         showWindow();
-        return;
+        if(isMinimized())
+        {
+          showWindowNormal();
+        }
         // if(isMinimized()) showNormal();
         // else show();
       }
+      break;
+      
+    case QSystemTrayIcon::DoubleClick:
+    case QSystemTrayIcon::MiddleClick:
+      // Если окно видно
+      if(isVisible())
+      {
+        hide();
+      }
+      else
+      {
+        showWindow();
+        if(isMinimized())
+        {
+          showWindowNormal();
+        }
+      }
+      break;
+      
     default:
-      ;
+      break;
   }
 }
 

--- a/src/views/mainWindow/MainWindow.h
+++ b/src/views/mainWindow/MainWindow.h
@@ -104,7 +104,8 @@ public slots:
 private slots:
 
  void showWindow();
-
+ void showWindowNormal();
+ 
  void fileNew(void);
  void fileOpen(void);
  bool fileSave(void);
@@ -154,6 +155,9 @@ private:
 
  void reloadSaveStage(void);
  void reloadLoadStage(void);
+ 
+ bool isActive() const;
+ void activate();
 
  QAction *actionTrayRestore;
  QAction *actionTrayMaximize;


### PR DESCRIPTION
Изменил поведение при клике на иконку в трее следующим образом:
-при одинарном клике окно всегда показывается(активируется, разворачивается)
-при двойном клике показывается или скрывается
Активация окна выполняется с учётом Minimized\Maximized
решает вопрос https://github.com/xintrea/mytetra_dev/issues/37

Можно добавить в параметр mainwingeometry флаг maximized чтобы пери перезапуске и скрытии свёрнутого окна тоже правильно восстанавливать состояние
