### PR TITLE
Исправил ошибку, возникающую при переименовании вложенных файлов.

### DIFF
--- a/src/controllers/attachTable/AttachTableController.cpp
+++ b/src/controllers/attachTable/AttachTableController.cpp
@@ -475,7 +475,7 @@ void AttachTableController::onEditFileName(void)
 
   // Данные изменяются
   Attach tempAttach=attachTableData->getAttach(id);
-  tempAttach.setField("fileName", newFileName);
+  tempAttach.renameFile(newFileName);
   attachTableData->modifyAttach(id, tempAttach);
 
   // Сохранение дерева веток

--- a/src/models/attachTable/Attach.cpp
+++ b/src/models/attachTable/Attach.cpp
@@ -392,8 +392,12 @@ QString Attach::constructFileName(const QString type, const QString id, const QS
     // Выясняется расширение по видимому имени файла
     QFileInfo fileInfo( fileName );
     QString suffix=fileInfo.suffix();
-
-    return id+"."+suffix;
+//Правельнее сделать так, но это может сломать совместимость
+//    if(suffix.length()>0){
+      return id+"."+suffix;
+//    }else{
+//      return id;
+//    }
   }
 
   // Для линка просто возвращается имя файла, куда указывает линк
@@ -559,4 +563,30 @@ void Attach::decryptDomElement(QDomElement &iDomElement)
       }
 
   iDomElement.setAttribute("crypt", "0");
+}
+
+void Attach::renameFile(QString newFileName){
+  if(newFileName.length()==0){
+    showMessageBox(QObject::tr("Invalid empty file name."));
+     return;
+  }
+
+  QString type=getField("type");  
+  if(type=="link")
+  {
+    // Имя файла для линка менять нельзя
+    showMessageBox(QObject::tr("Unable to rename a file which attached as a link."));
+    return;
+  }
+  QFile file(getFullInnerFileName());
+  file.setPermissions(QFile::ReadOther | QFile::WriteOther);
+  if(!file.exists())
+  {
+    showMessageBox(QObject::tr("Unable to rename the file %1 from disk: file not found.").arg( getFullInnerFileName() ));
+    return;
+  }
+  
+  QString resultFileName=getFullInnerDirName()+"/"+constructFileName(type, getField("id"), newFileName);
+  file.rename(resultFileName);
+  setField("fileName", newFileName);
 }

--- a/src/models/attachTable/Attach.h
+++ b/src/models/attachTable/Attach.h
@@ -58,7 +58,8 @@ public:
 
   // Расшифровка переданного DOM-элемента, полученного из тега <file> и его атрибутов
   static void decryptDomElement(QDomElement &iDomElement);
-
+  
+  void renameFile(QString newFileName);
 protected:
 
   void init(AttachTableData *iParentTable);


### PR DESCRIPTION
Если, при переименовании вложенного файла, изменить его расширение, то файл будет не доступен.

Если убрать расширение файла то имя файла останется
data\base\14841102376yloo11qkt\14841102771dc1s5wo8p.txt
программа покажет
data/base/14841102376yloo11qkt/14841102771dc1s5wo8p.
а в xml будет
<file id="14841102771dc1s5wo8p" fileName="testBug" type="file"/>

Так происходит из за того что при переименовании файла, изменяется только поле в mytetra.xml

