### PR TITLE
Revert "Изменил поведение при клике на иконку в трее"

### DIFF
--- a/src/views/mainWindow/MainWindow.cpp
+++ b/src/views/mainWindow/MainWindow.cpp
@@ -905,31 +905,9 @@ void MainWindow::setupIconActions(void)
 void MainWindow::showWindow()
 {
   activateWindow();
-  show();
-  raise();
-}
-
-void MainWindow::showWindowNormal()
-{
-  activateWindow();
   showNormal();
   raise();
 }
-
-void MainWindow::activate() {
-//	bool wasHidden = !isVisible();
-	setWindowState(windowState() & ~Qt::WindowMinimized);
-	setVisible(true);
-	activateWindow();
-//	if (wasHidden) {
-//			show();
-//	}
-}
-
-bool MainWindow::isActive() const {
-	return isActiveWindow() && isVisible() && !(windowState() & Qt::WindowMinimized);
-}
-
 
 
 void MainWindow::createTrayIcon(void)
@@ -969,52 +947,43 @@ void MainWindow::iconActivated(QSystemTrayIcon::ActivationReason reason)
   switch (reason)
   {
     case QSystemTrayIcon::Trigger:
+    case QSystemTrayIcon::DoubleClick:
       // Если окно видно
       if(isVisible())
       {
-        if(!isActive()){
-          qDebug() << "If visible and not active";
-          activate();
+        // Если окно неактивно, значит активно другое (и возможно оно перекрывает окно MyTetra)
+        // Не работает в Windows, в Linux не проверял
+        // Причина неработоспособности - при клике на иконку, окно MyTera всегда становится неактивным (т.к. активен систрей)
+        // И условие срабатывает всегда. Доделать или отказаться
+        // if(QGuiApplication::applicationState() == Qt::ApplicationInactive)
+        // {
+        //   activateWindow();
+        //   return;
+        // }
+
+        if(isMinimized())
+        {
+          qDebug() << "If visible and minimized";
+          showWindow();
+          return;
         }
-        //при клике на иконку, окно MyTera всегда становится неактивным (т.к. активен систрей)   
-//        else
-//        {
-//          qDebug() << "If visible and active then Hide";
-//          hide();
-//        }
+        else
+        {
+          qDebug() << "Hide";
+          hide();
+          return;
+        }
       }
       else
       {
         qDebug() << "If not visible";
         showWindow();
-        if(isMinimized())
-        {
-          showWindowNormal();
-        }
+        return;
         // if(isMinimized()) showNormal();
         // else show();
       }
-      break;
-      
-    case QSystemTrayIcon::DoubleClick:
-    case QSystemTrayIcon::MiddleClick:
-      // Если окно видно
-      if(isVisible())
-      {
-        hide();
-      }
-      else
-      {
-        showWindow();
-        if(isMinimized())
-        {
-          showWindowNormal();
-        }
-      }
-      break;
-      
     default:
-      break;
+      ;
   }
 }
 

--- a/src/views/mainWindow/MainWindow.h
+++ b/src/views/mainWindow/MainWindow.h
@@ -104,8 +104,7 @@ public slots:
 private slots:
 
  void showWindow();
- void showWindowNormal();
- 
+
  void fileNew(void);
  void fileOpen(void);
  bool fileSave(void);
@@ -155,9 +154,6 @@ private:
 
  void reloadSaveStage(void);
  void reloadLoadStage(void);
- 
- bool isActive() const;
- void activate();
 
  QAction *actionTrayRestore;
  QAction *actionTrayMaximize;


### PR DESCRIPTION
Reverts xintrea/mytetra_dev#46

Проверил, и вот что хочу сказать.

1. При одиночных кликах на иконку в трее окно MyTetra должно то скрываться то появляться. С твоими изменениями окно появляется, но не скрывается вообще. Это не хорошо

2. Ты пишешь, что по двойному клику по иконке в трее окно должно то скрываться то раскрываться. Но у меня вообще ничего не происходит.

Таким образом, я вообще не могу скрыть окно - могу только свернуть его или нажать на крестик. А с трея управление появлением/скрытием окна через клики стало невозможно.

Linux Debian 9 Stable
LxQt 0.11.1
