### PR TITLE
Сделана возможность задавать размер шага табуляции для клавиши <Tab>.

### DIFF
--- a/app/bin/resource/standartconfig/android/editorconf.ini
+++ b/app/bin/resource/standartconfig/android/editorconf.ini
@@ -5,6 +5,7 @@ monospace_font="Courier New,12,-1,5,50,0,0,0,0,0"
 monospace_font_size=11
 monospace_font_size_apply=1
 indent_step=10
+tab_size=4
 finddialog_geometry="286,100,512,307"
 version=6
 code_font="Courier New,12,-1,5,50,0,0,0,0,0"

--- a/app/bin/resource/standartconfig/any/editorconf.ini
+++ b/app/bin/resource/standartconfig/any/editorconf.ini
@@ -10,6 +10,7 @@ default_font_size=11
 expand_tools_lines=1
 finddialog_geometry="296,0,290,167"
 indent_step=20
+tab_size=4
 monospace_font="FreeMono,12,-1,5,50,0,0,0,0,0"
 monospace_font_size=11
 monospace_font_size_apply=1

--- a/app/bin/resource/standartconfig/meego/editorconf.ini
+++ b/app/bin/resource/standartconfig/meego/editorconf.ini
@@ -5,6 +5,7 @@ monospace_font="Courier New,12,-1,5,50,0,0,0,0,0"
 monospace_font_size=11
 monospace_font_size_apply=1
 indent_step=10
+tab_size=4
 finddialog_geometry="286,100,512,307"
 version=6
 code_font="Courier New,12,-1,5,50,0,0,0,0,0"

--- a/app/src/libraries/wyedit/Editor.cpp
+++ b/app/src/libraries/wyedit/Editor.cpp
@@ -200,8 +200,9 @@ void Editor::setupEditorTextArea(void)
   textArea->selectAll();
   textArea->setCurrentFont(font);
   textArea->setFont(font);
+
   // Устанавка размера табуляции для клавиши Tab
-  textArea->setTabStopDistance( QFontMetricsF(textArea->font()).width('A') * editorConfig->get_tab_size() );
+  setTabSize();
 }
 
 
@@ -1280,8 +1281,9 @@ void Editor::onSettingsClicked(void)
   // Создается окно настроек, после выхода из этой функции окно удалится
   EditorConfigDialog dialog;
   dialog.show();
+
   // Устанавка размера табуляции для клавиши Tab
-  textArea->setTabStopDistance( QFontMetricsF(textArea->font()).width('A') * editorConfig->get_tab_size() );
+  setTabSize();
 }
 
 
@@ -1358,6 +1360,22 @@ void Editor::onShowTextClicked(void)
   showText->setDocument( cloneDocument );
 
   showText->show();
+}
+
+
+void Editor::setTabSize()
+{
+    // Устанавка размера табуляции для клавиши Tab
+    // Учитываем среднюю ширину глифов в шрифте
+    textArea->setTabStopDistance(
+                QFontMetrics(textArea->currentCharFormat().font()).averageCharWidth() *
+                editorConfig->get_tab_size()
+                );
+
+    // Альтернатива, не учитывающая среднюю ширину глифов в шрифте
+//    textArea->setTabStopDistance(
+//                textArea->fontMetrics().width(QLatin1Char('a')
+//                                              ) * editorConfig->get_tab_size() );
 }
 
 

--- a/app/src/libraries/wyedit/Editor.cpp
+++ b/app/src/libraries/wyedit/Editor.cpp
@@ -200,6 +200,8 @@ void Editor::setupEditorTextArea(void)
   textArea->selectAll();
   textArea->setCurrentFont(font);
   textArea->setFont(font);
+  // Устанавка размера табуляции для клавиши Tab
+  textArea->setTabStopDistance( QFontMetricsF(textArea->font()).width('A') * editorConfig->get_tab_size() );
 }
 
 
@@ -1278,6 +1280,8 @@ void Editor::onSettingsClicked(void)
   // Создается окно настроек, после выхода из этой функции окно удалится
   EditorConfigDialog dialog;
   dialog.show();
+  // Устанавка размера табуляции для клавиши Tab
+  textArea->setTabStopDistance( QFontMetricsF(textArea->font()).width('A') * editorConfig->get_tab_size() );
 }
 
 

--- a/app/src/libraries/wyedit/Editor.h
+++ b/app/src/libraries/wyedit/Editor.h
@@ -250,6 +250,9 @@ private:
  void setupFormatters(void);
  void assembly(void);
 
+ // Устанавка размера табуляции для клавиши Tab
+ void setTabSize();
+
  // Переопределение событий обработки клавиш
  // нужны для определения момента undo/redo
  virtual void keyPressEvent(QKeyEvent *event);

--- a/app/src/libraries/wyedit/EditorConfig.cpp
+++ b/app/src/libraries/wyedit/EditorConfig.cpp
@@ -263,6 +263,27 @@ void EditorConfig::set_indent_step(int i)
 }
 
 
+// -------------------------------------------
+// Настройки размера табуляции для клавиши Tab
+// -------------------------------------------
+
+int EditorConfig::get_tab_size(void)
+{
+    int n=get_parameter("tab_size").toInt();
+
+    if(n==0)
+        return 4;
+    else
+        return n;
+}
+
+
+void EditorConfig::set_tab_size(int i)
+{
+    conf->setValue("tab_size",i);
+}
+
+
 // -----------------------------
 // Координаты поискового диалога
 // -----------------------------
@@ -369,6 +390,7 @@ void EditorConfig::update_version_process(void)
     parameterFunctions << get_parameter_table_11;
     parameterFunctions << get_parameter_table_12;
     parameterFunctions << get_parameter_table_13;
+    parameterFunctions << get_parameter_table_14;
 
     for(int i=1; i<parameterFunctions.count()-1; ++i)
         if(fromVersion<=i)
@@ -629,6 +651,26 @@ QStringList EditorConfig::get_parameter_table_13(bool withEndSignature)
 
     // В параметр tools_line_1 добавляется "math_expression"
     // см. метод update_version_change_value()
+
+    if(withEndSignature)
+        table << "0" << "0" << "0";
+
+    return table;
+}
+
+
+QStringList EditorConfig::get_parameter_table_14(bool withEndSignature)
+{
+    // Таблица параметров
+    // Имя, Тип, Значение на случай когда в конфиге параметра прочему-то нет
+    QStringList table;
+
+    // Старые параметры, аналогичные версии 13
+    table << get_parameter_table_13(false);
+
+    // Добавляются новые параметры
+    // размер табуляции (клавиша Tab)
+    table << "tab_size" << "int" << "4";
 
     if(withEndSignature)
         table << "0" << "0" << "0";

--- a/app/src/libraries/wyedit/EditorConfig.h
+++ b/app/src/libraries/wyedit/EditorConfig.h
@@ -53,6 +53,10 @@ public:
     int get_indent_step(void);
     void set_indent_step(int i);
 
+    // Размер табуляции для клавиши Tab
+    int get_tab_size(void);
+    void set_tab_size(int i);
+
     QString get_finddialog_geometry(void);
     void set_finddialog_geometry(QString geometry);
 
@@ -92,6 +96,7 @@ private:
     static QStringList get_parameter_table_11(bool withEndSignature=true);
     static QStringList get_parameter_table_12(bool withEndSignature=true);
     static QStringList get_parameter_table_13(bool withEndSignature=true);
+    static QStringList get_parameter_table_14(bool withEndSignature=true);
 
     static QStringList remove_option(QStringList table, QString optionName);
 

--- a/app/src/libraries/wyedit/EditorConfigMisc.cpp
+++ b/app/src/libraries/wyedit/EditorConfigMisc.cpp
@@ -42,6 +42,17 @@ void EditorConfigMisc::setupUi(void)
  indentStep->setMaximum(250);
  indentStep->setValue(conf->get_indent_step());
 
+ // Размер табуляции для клавиши Tab
+ tabStopDistanceLabel=new QLabel(this);
+ tabStopDistanceLabel->setText(tr("Tab size"));
+
+ tabStopDistanceFlexionLabel=new QLabel(this);
+ tabStopDistanceFlexionLabel->setText(tr("letters"));
+
+ tabStopDistanceSpinBox=new QSpinBox(this);
+ tabStopDistanceSpinBox->setMinimum(1);
+ tabStopDistanceSpinBox->setMaximum(50);
+ tabStopDistanceSpinBox->setValue(conf->get_tab_size());
 
  // Кнопка редактирования файла конфигурации WyEdit
  editWyEditConfigFile=new QPushButton(this);
@@ -65,6 +76,10 @@ void EditorConfigMisc::assembly(void)
   configLayout->addWidget(indentStep,         0, 1);
   configLayout->addWidget(indentStepFlexion, 0, 2);
 
+  // Компановка контролов "Шаг дистанции для клавиши Tab"
+  configLayout->addWidget(tabStopDistanceLabel,         1, 0);
+  configLayout->addWidget(tabStopDistanceSpinBox,       1, 1);
+  configLayout->addWidget(tabStopDistanceFlexionLabel,  1, 2);
 
   // Группировщик виджетов для опасной зоны
   QGroupBox *dangerBox=new QGroupBox(this);
@@ -106,6 +121,11 @@ int EditorConfigMisc::applyChanges(void)
   // Если был изменен размер основного шрифта
  if(conf->get_indent_step()!=indentStep->value()) {
   conf->set_indent_step(indentStep->value());
+ }
+
+ // Если был изменен размер табуляции для клавиши Tab
+ if(conf->get_tab_size()!=tabStopDistanceSpinBox->value()) {
+   conf->set_tab_size(tabStopDistanceSpinBox->value());
  }
  
  return difficultChanges;

--- a/app/src/libraries/wyedit/EditorConfigMisc.h
+++ b/app/src/libraries/wyedit/EditorConfigMisc.h
@@ -31,6 +31,11 @@ private:
   QLabel *indentStepFlexion;
   QSpinBox *indentStep;
 
+  // Размер табуляции для клавиши Tab
+  QLabel *tabStopDistanceLabel;
+  QLabel *tabStopDistanceFlexionLabel;
+  QSpinBox *tabStopDistanceSpinBox;
+
   QPushButton *editWyEditConfigFile;
   
   EditorConfig *conf;


### PR DESCRIPTION
Для этого в диалоге Настройки редактора текста на вкладке Misc введен QSpinBox с диаппазоном значений от 1 до 50 (букв).

Для чего нужна эта возможность?
Заданное разработчиками Qt по-умолчанию значение TabStopDictance для QTextEdit слишком большое, и текст, в котором есть табуляции, выглядит не очень красиво.
Поэтому сделана возможность задавать это значение от 1 до 50. По-умолчанию установлено значение 4 буквы.

При нажатии кнопки Ok диалога Настройки редактора происходит автоматическое изменение TabStopDistance для редактора текста.
При запуске MyTetra происходит считывание значения tab_size из editorconf.ini и изменение TabStopDistance для редактора текста.