### PR TITLE
Исправлена ситуация, когда при работе с кнопками форматирования не всегда снималось форматирование с выделенного текста

### DIFF
--- a/app/src/libraries/wyedit/formatters/TypefaceFormatter.cpp
+++ b/app/src/libraries/wyedit/formatters/TypefaceFormatter.cpp
@@ -53,6 +53,18 @@ void TypefaceFormatter::smartFormat(int formatType)
     // Если выделение есть
     if(textArea->textCursor().hasSelection())
     {
+        // Переназначение позиций выделения, иначе снятие форматирования не срабатывает
+        // в случае выделения справа-налево (снизу-вверх)
+        QTextCursor cursor = textArea->textCursor();
+        const int anchor = cursor.anchor();
+        const int position = cursor.position();
+        if (anchor > position)
+        {
+            cursor.setPosition(position, QTextCursor::MoveAnchor);
+            cursor.setPosition(anchor, QTextCursor::KeepAnchor);
+            textArea->setTextCursor(cursor);
+        }
+
         if(formatType==Bold)
         {
             if(textArea->fontWeight() != QFont::Bold)


### PR DESCRIPTION
Сделано переназначение позиций выделения, иначе снятие форматирования для не срабатывает в случае выделения справа-налево (снизу-вверх)
Данное исправление устраняет ситуацию, когда при выделении текста слева-направо форматирование **bold**, _italic_ и т.д. срабатывает, а снятие этого форматирования этими же кнопками на этом выделении при выделении текста справа-налево - не работает (приходилось, чтобы снять форматирование, выделять нужное место слева-направо).