### PR TITLE
Улучшено форматирование текста цветом

### DIFF
--- a/app/src/libraries/ShortcutManager.cpp
+++ b/app/src/libraries/ShortcutManager.cpp
@@ -89,6 +89,7 @@ void ShortcutManager::initDefaultKeyTable()
     defaultKeyTable.insert("editor-alignRight",          data{ QKeySequence("Ctrl+R"), QObject::tr("Align right"), QObject::tr("") });
     defaultKeyTable.insert("editor-alignWidth",          data{ QKeySequence("Ctrl+J"), QObject::tr("Align width"), QObject::tr("") });
     defaultKeyTable.insert("editor-fontColor",           data{ QKeySequence("Ctrl+Alt+C"), QObject::tr("Text color"), QObject::tr("") });
+    defaultKeyTable.insert("editor-backgroundColor",     data{ QKeySequence("Ctrl+Shift+C"), QObject::tr("Background color"), QObject::tr("") });
     defaultKeyTable.insert("editor-findText",            data{ QKeySequence("Ctrl+F"), QObject::tr("Find text"), QObject::tr("Find text in current note") });
     defaultKeyTable.insert("editor-settings",            data{ QKeySequence("Ctrl+Alt+G"), QObject::tr("Editor settings"), QObject::tr("") });
     defaultKeyTable.insert("editor-reference",           data{ QKeySequence("Ctrl+Shift+U"), QObject::tr("Edit reference URL"), QObject::tr("") });

--- a/app/src/libraries/ShortcutManager.cpp
+++ b/app/src/libraries/ShortcutManager.cpp
@@ -88,8 +88,8 @@ void ShortcutManager::initDefaultKeyTable()
     defaultKeyTable.insert("editor-alignCenter",         data{ QKeySequence("Ctrl+E"), QObject::tr("Align center"), QObject::tr("") });
     defaultKeyTable.insert("editor-alignRight",          data{ QKeySequence("Ctrl+R"), QObject::tr("Align right"), QObject::tr("") });
     defaultKeyTable.insert("editor-alignWidth",          data{ QKeySequence("Ctrl+J"), QObject::tr("Align width"), QObject::tr("") });
-    defaultKeyTable.insert("editor-fontColor",           data{ QKeySequence("Ctrl+Alt+C"), QObject::tr("Text color"), QObject::tr("") });
-    defaultKeyTable.insert("editor-backgroundColor",     data{ QKeySequence("Ctrl+Shift+C"), QObject::tr("Background color"), QObject::tr("") });
+    defaultKeyTable.insert("editor-fontColor",           data{ QKeySequence("Alt+C"), QObject::tr("Text color"), QObject::tr("") });
+    defaultKeyTable.insert("editor-backgroundColor",     data{ QKeySequence("Alt+B"), QObject::tr("Background color"), QObject::tr("") });
     defaultKeyTable.insert("editor-findText",            data{ QKeySequence("Ctrl+F"), QObject::tr("Find text"), QObject::tr("Find text in current note") });
     defaultKeyTable.insert("editor-settings",            data{ QKeySequence("Ctrl+Alt+G"), QObject::tr("Editor settings"), QObject::tr("") });
     defaultKeyTable.insert("editor-reference",           data{ QKeySequence("Ctrl+Shift+U"), QObject::tr("Edit reference URL"), QObject::tr("") });

--- a/app/src/libraries/wyedit/Editor.cpp
+++ b/app/src/libraries/wyedit/Editor.cpp
@@ -281,6 +281,20 @@ void Editor::setupSignals(void)
   connect(typefaceFormatter,      &TypefaceFormatter::changeFontcolor,
           editorToolBarAssistant, &EditorToolBarAssistant::onChangeFontcolor,
           Qt::DirectConnection);
+  connect(textArea,               &EditorTextArea::currentCharFormatChanged,
+          editorToolBarAssistant, &EditorToolBarAssistant::onChangeIconFontColor,
+          Qt::DirectConnection);
+
+  // Соединение сигналов и слотов обрабортки для цвета выделения текста
+  connect(typefaceFormatter, &TypefaceFormatter::changeBackgroundcolor,
+          textArea,          &EditorTextArea::onChangeBackgroundColor,
+          Qt::DirectConnection);
+  connect(typefaceFormatter,      &TypefaceFormatter::changeBackgroundcolor,
+          editorToolBarAssistant, &EditorToolBarAssistant::onChangeBackgroundColor,
+          Qt::DirectConnection);
+  connect(textArea,               &EditorTextArea::currentCharFormatChanged,
+          editorToolBarAssistant, &EditorToolBarAssistant::onChangeIconBackgroundColor,
+          Qt::DirectConnection);
 
 
   connect(this,                   &Editor::changeFontselectOnDisplay,
@@ -456,6 +470,10 @@ void Editor::setupToolsSignals(void)
 
     connect(editorToolBarAssistant->fontColor, &QAction::triggered,
             typefaceFormatter,                 &TypefaceFormatter::onFontcolorClicked);
+
+    // Цвет фона текста
+    connect(editorToolBarAssistant->backgroundColor, &QAction::triggered,
+            typefaceFormatter,                       &TypefaceFormatter::onBackgroundcolorClicked);
 
     connect(editorToolBarAssistant->indentPlus, &QAction::triggered,
             placementFormatter,                 &PlacementFormatter::onIndentplusClicked);

--- a/app/src/libraries/wyedit/EditorConfig.cpp
+++ b/app/src/libraries/wyedit/EditorConfig.cpp
@@ -369,6 +369,7 @@ void EditorConfig::update_version_process(void)
     parameterFunctions << get_parameter_table_11;
     parameterFunctions << get_parameter_table_12;
     parameterFunctions << get_parameter_table_13;
+    parameterFunctions << get_parameter_table_14;
 
     for(int i=1; i<parameterFunctions.count()-1; ++i)
         if(fromVersion<=i)
@@ -637,6 +638,25 @@ QStringList EditorConfig::get_parameter_table_13(bool withEndSignature)
 }
 
 
+QStringList EditorConfig::get_parameter_table_14(bool withEndSignature)
+{
+    // Таблица параметров
+    // Имя, Тип, Значение на случай когда в конфиге параметра прочему-то нет
+    QStringList table;
+
+    // Старые параметры, аналогичные версии 13
+    table << get_parameter_table_13(false);
+
+    // В параметр tools_line_2 добавляется "separator,fontcolor,backgroundcolor,separator"
+    // см. метод update_version_change_value()
+
+    if(withEndSignature)
+        table << "0" << "0" << "0";
+
+    return table;
+}
+
+
 // Метод разрешения конфликтов если исходные и конечные типы не совпадают
 // Должен включать в себя логику обработки только тех параметров
 // и только для тех версий конфигов, которые действительно
@@ -745,6 +765,27 @@ QString EditorConfig::update_version_change_value(int versionFrom,
                 else
                     result=result+",math_expression";
             }
+
+    if(versionFrom==13 && versionTo==14)
+    {
+        if(name=="tools_line_2")
+        {
+            if(!result.contains("fontcolor") && !result.contains("backgroundcolor"))
+            {
+                if(result.contains("fontsize"))
+                    result.replace("fontsize", "fontsize,separator,fontcolor,backgroundcolor,separator");
+                else
+                    result=result+",separator,fontcolor,backgroundcolor,separator";
+            }
+            else
+            {
+                if(result.contains("fontcolor"))
+                    result.replace("fontcolor", "fontcolor,backgroundcolor,separator");
+                else
+                    result=result+",backgroundcolor,separator";
+            }
+        }
+    }
 
     return result;
 }

--- a/app/src/libraries/wyedit/EditorConfig.h
+++ b/app/src/libraries/wyedit/EditorConfig.h
@@ -92,6 +92,7 @@ private:
     static QStringList get_parameter_table_11(bool withEndSignature=true);
     static QStringList get_parameter_table_12(bool withEndSignature=true);
     static QStringList get_parameter_table_13(bool withEndSignature=true);
+    static QStringList get_parameter_table_14(bool withEndSignature=true);
 
     static QStringList remove_option(QStringList table, QString optionName);
 

--- a/app/src/libraries/wyedit/EditorTextArea.cpp
+++ b/app/src/libraries/wyedit/EditorTextArea.cpp
@@ -576,7 +576,7 @@ void EditorTextArea::onDownloadImagesSuccessfull(const QString html,
 }
 
 
-void EditorTextArea::onChangeFontcolor(QColor selectedColor)
+void EditorTextArea::onChangeFontcolor(const QColor &selectedColor)
 {
   // TRACELOG
 
@@ -592,6 +592,29 @@ void EditorTextArea::onChangeFontcolor(QColor selectedColor)
 
     QTextCharFormat format;
     format.setForeground(selectedColor);
+
+    cursor.mergeCharFormat(format);
+  }
+}
+
+
+// Изменение цвета фона текста
+void EditorTextArea::onChangeBackgroundColor(const QColor &selectedColor)
+{
+  // TRACELOG
+
+  // Если выделение есть
+  if(textCursor().hasSelection())
+    setTextBackgroundColor(selectedColor); // Меняется цвет фона
+  else
+  {
+    // Иначе надо выделить дополнительным курсором слово на
+    // котором стоит курсор
+    QTextCursor cursor=textCursor();
+    cursor.select(QTextCursor::WordUnderCursor);
+
+    QTextCharFormat format;
+    format.setBackground(selectedColor);
 
     cursor.mergeCharFormat(format);
   }

--- a/app/src/libraries/wyedit/EditorTextArea.h
+++ b/app/src/libraries/wyedit/EditorTextArea.h
@@ -48,7 +48,8 @@ class EditorTextArea : public QTextEdit
  public slots:
   void show_indetedge(bool i);
   void set_indentedge_pos(int i);
-  void onChangeFontcolor(QColor selectedColor);
+  void onChangeFontcolor(const QColor &selectedColor);
+  void onChangeBackgroundColor(const QColor &selectedColor);
   void onChangeFontFamily(QString fontFamily);
   void onChangeFontPointSize(int n);
 

--- a/app/src/libraries/wyedit/EditorToolBar.cpp
+++ b/app/src/libraries/wyedit/EditorToolBar.cpp
@@ -182,8 +182,14 @@ void EditorToolBar::setupToolBarTools(void)
 
   // Кнопка выбора цвета шрифта
   fontColor=new QAction(this);
-  fontColor->setIcon(QIcon(":/resource/pic/edit_fontcolor.svg"));
+//  fontColor->setIcon(QIcon(":/resource/pic/edit_fontcolor.svg"));
   fontColor->setObjectName("editor_tb_fontcolor");
+
+
+  // Кнопка выбора цвета фона текста
+  backgroundColor=new QAction(this);
+//  backgroundColor->setIcon(QIcon(":/resource/pic/edit_fontcolor.svg"));
+  backgroundColor->setObjectName("editor_tb_backgroundcolor");
 
 
   // Кнопка вызова виджета поиска текста
@@ -316,6 +322,7 @@ void EditorToolBar::setupShortcuts(void)
     shortcutManager.initAction("editor-alignRight", alignRight);
     shortcutManager.initAction("editor-alignWidth", alignWidth);
     shortcutManager.initAction("editor-fontColor", fontColor);
+    shortcutManager.initAction("editor-backgroundColor", backgroundColor);
     shortcutManager.initAction("editor-findText", findText);
     shortcutManager.initAction("editor-settings", settings);
     shortcutManager.initAction("editor-reference", reference);

--- a/app/src/libraries/wyedit/EditorToolBar.h
+++ b/app/src/libraries/wyedit/EditorToolBar.h
@@ -57,6 +57,7 @@ public:
   EditorFontFamilyComboBox *fontSelect;
   EditorFontSizeComboBox   *fontSize;
   QAction                  *fontColor;
+  QAction                  *backgroundColor;
 
   QAction *reference;
 
@@ -130,6 +131,9 @@ protected:
   void updateToolsLines(void);
 
   QAction* generateAction(QIcon icon=QIcon());
+
+  // Размер иконок на панели инструментов редактора
+  QSize getIconSize() const {return toolsLine1.iconSize();}
 
 };
 

--- a/app/src/libraries/wyedit/EditorToolBarAssistant.cpp
+++ b/app/src/libraries/wyedit/EditorToolBarAssistant.cpp
@@ -49,7 +49,6 @@ EditorToolBarAssistant::EditorToolBarAssistant(QWidget *parent,
 
   currentFontFamily="";
   currentFontSize=0;
-  currentFontColor="#000000";
   flagSetFontParametersEnabled=true;
 
   // Инициализация панели инструментов
@@ -142,21 +141,49 @@ void EditorToolBarAssistant::onChangeFontPointSize(int n)
 }
 
 
-void EditorToolBarAssistant::onChangeFontcolor(QColor color)
+// Изменение цвета иконки выделения цвета шрифта
+void EditorToolBarAssistant::onChangeFontcolor(const QColor &color)
 {
     // TRACELOG
 
+    QPixmap pix(getIconSize());
     // Если цвет правильный
     if(color.isValid())
-    {
-        if(fontColor->associatedWidgets().size()>0) {
-            QToolButton* currentButton=qobject_cast<QToolButton*>(fontColor->associatedWidgets()[0]);
-            currentButton->setPalette(QPalette(color)); // Меняется цвет кнопки, отвечающей за цвет шрифта
-        }
+        pix.fill(color);
+    else
+        pix.fill(QApplication::palette().foreground().color());
+    fontColor->setIcon(pix);
+}
 
-        currentFontColor=color.name(); // todo: подумать, а нужна ли эта переменная
-    }
 
+// Изменение цвета иконки цвета шрифта, в зависимости от положения курсора
+void EditorToolBarAssistant::onChangeIconFontColor(const QTextCharFormat &format)
+{
+    QColor color = format.foreground().color();
+    onChangeFontcolor(color);
+}
+
+
+// Изменение цвета иконки выделения фона текста
+void EditorToolBarAssistant::onChangeBackgroundColor(const QColor &color)
+{
+    // TRACELOG
+
+    QPixmap pix(getIconSize());
+    // Если цвет правильный
+    if(color.isValid())
+        pix.fill(color);
+    else
+        pix.fill(QApplication::palette().background().color());
+    backgroundColor->setIcon(pix);
+}
+
+
+// Изменение цвета иконки выделения фона текста, в зависимости от положения курсора
+void EditorToolBarAssistant::onChangeIconBackgroundColor(const QTextCharFormat &format)
+{
+    QColor color = format.background().color();
+    onChangeBackgroundColor(color);
 }
 
 

--- a/app/src/libraries/wyedit/EditorToolBarAssistant.h
+++ b/app/src/libraries/wyedit/EditorToolBarAssistant.h
@@ -11,6 +11,7 @@
 
 class Editor;
 class EditorTextArea;
+class QTextCharFormat;
 
 class EditorToolBarAssistant : public EditorToolBar
 {
@@ -64,7 +65,10 @@ public slots:
   void onChangeFontsizeOnDisplay(int n);
   void onChangeFontFamily(QString fontFamily);
   void onChangeFontPointSize(int n);
-  void onChangeFontcolor(QColor color);
+  void onChangeFontcolor(const QColor &color);
+  void onChangeIconFontColor(const QTextCharFormat &format);
+  void onChangeBackgroundColor(const QColor &color);
+  void onChangeIconBackgroundColor(const QTextCharFormat &format);
 
 protected:
 
@@ -75,7 +79,6 @@ protected:
 
   QString currentFontFamily;
   int     currentFontSize;
-  QString currentFontColor;
 
   bool flagSetFontParametersEnabled; // Флаг разрешения/запрета срабатывания слотов установки параметров шрифта
 

--- a/app/src/libraries/wyedit/formatters/TypefaceFormatter.cpp
+++ b/app/src/libraries/wyedit/formatters/TypefaceFormatter.cpp
@@ -1158,8 +1158,26 @@ void TypefaceFormatter::onFontcolorClicked()
     if(selectedColor.isValid())
     {
         // Меняется цвет кнопки
-        // editor->editorToolBar->fontColor->setPalette(QPalette(selectedColor));
-        // editor->currentFontColor=selectedColor.name(); // Запоминается текущий цвет (подумать, доделать)
         emit changeFontcolor( selectedColor );
+    }
+}
+
+
+// Слот, срабатыващий при нажатии на кнопку выбора цвета фона текста
+void TypefaceFormatter::onBackgroundcolorClicked()
+{
+    // TRACELOG
+
+    // Текущий цвет фона возле курсора
+    QColor currentColor=textArea->textBackgroundColor();
+
+    // Диалог запроса цвета
+    QColor selectedColor=QColorDialog::getColor(currentColor, editor);
+
+    // Если цвет выбран, и он правильный
+    if(selectedColor.isValid())
+    {
+        // Меняется цвет кнопки
+        emit changeBackgroundcolor( selectedColor );
     }
 }

--- a/app/src/libraries/wyedit/formatters/TypefaceFormatter.h
+++ b/app/src/libraries/wyedit/formatters/TypefaceFormatter.h
@@ -26,7 +26,8 @@ signals:
     void changeFontsizeOnDisplay(int n);
     void changeFontFamily(QString fontFamily);
     void changeFontPointSize(int n);
-    void changeFontcolor(QColor color);
+    void changeFontcolor(const QColor &color);
+    void changeBackgroundcolor(const QColor &color);
 
 public slots:
 
@@ -43,6 +44,7 @@ public slots:
     void onFontselectChanged(const QFont &font);
     void onFontsizeChanged(int n);
     void onFontcolorClicked();
+    void onBackgroundcolorClicked();
 
 private:
 

--- a/app/src/models/appConfig/AppConfig.cpp
+++ b/app/src/models/appConfig/AppConfig.cpp
@@ -1478,7 +1478,7 @@ QStringList AppConfig::get_parameter_table_20(bool withEndSignature)
 
   // Новые параметры
   if(globalParameters.getTargetOs()=="android")
-    table << "hideEditorTools" << "QString" << "italic,underline,monospace,alignleft,aligncenter,alignright,alignwidth,numericlist,dotlist,indentplus,indentminus,showformatting,showhtml,fontcolor,expand_edit_area,save,createtable,table_add_row,table_remove_row,table_add_col,table_remove_col,table_merge_cells,table_split_cell"; // В Андроид прячутся инструменты сложного форматирования текста
+    table << "hideEditorTools" << "QString" << "italic,underline,monospace,alignleft,aligncenter,alignright,alignwidth,numericlist,dotlist,indentplus,indentminus,showformatting,showhtml,fontcolor,backgroundcolor,expand_edit_area,save,createtable,table_add_row,table_remove_row,table_add_col,table_remove_col,table_merge_cells,table_split_cell"; // В Андроид прячутся инструменты сложного форматирования текста
   else
     table << "hideEditorTools" << "QString" << ""; // На десктопе скрываемых кнопок редактора нет
 


### PR DESCRIPTION
1. Улучшено форматирование текста выбранным цветом шрифта. _Устранено
падение приложения при выборе цвета шрифта._ Сделано цветовое изменение
иконки кнопки цвета шрифта, в зависимости от цвета шрифта текста под
курсором.
2. Сделано форматирование либо выделенного текста, либо слова под
курсором выбранным цветом фона текста. Сделано цветовое изменение иконки
кнопки цвета фона, в зависимости от цвета фона текста под курсором.
Создана быстрая клавиша Ctrl+Shift+C.