### PR TITLE
Сделано атомарная обработка для форматирования в Code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ Makefile
 qdevelop-settings.db
 qrc_mytetra.cpp
 *.pro.user
+*.pro.user.*
 
 /app/bin/*
 !/app/bin/resource

--- a/app/src/libraries/wyedit/formatters/TypefaceFormatter.cpp
+++ b/app/src/libraries/wyedit/formatters/TypefaceFormatter.cpp
@@ -173,6 +173,8 @@ void TypefaceFormatter::onCodeClicked(void)
     if(!textArea->textCursor().hasSelection())
         return;
 
+    textArea->textCursor().beginEditBlock();
+
     // Обработка мягкого переноса в выделенном тексте
     // Учитываются мягкие переносы до выделенного текста (1-й символ до выделения) и в выделенных абзацах
     workingSoftCarryInSelection();
@@ -208,8 +210,6 @@ void TypefaceFormatter::onCodeClicked(void)
     else
         enableIndent=true; // Выбран четко блок (блоки) текста, нужно делать отступ
 
-
-    textArea->textCursor().beginEditBlock();
 
     // Вначале происходит преобразование фрагмента в чистый текст (onClearClicked() не подходит, так как съедается табуляция)
     onTextOnlyClicked();
@@ -1178,6 +1178,8 @@ void TypefaceFormatter::workingSoftCarryInSelection()
     if(!textArea->textCursor().hasSelection())
         return;
 
+    int scrollBarPosition=editor->getScrollBarPosition();
+
     // Запоминаем первоначальное выделение текста
     int selectionStart = textArea->textCursor().selectionStart();
     int selectionEnd   = textArea->textCursor().selectionEnd();
@@ -1233,5 +1235,7 @@ void TypefaceFormatter::workingSoftCarryInSelection()
     textCursor.setPosition(selectionStart, QTextCursor::MoveAnchor);
     textCursor.setPosition(selectionEnd, QTextCursor::KeepAnchor);
     textArea->setTextCursor(textCursor);
+
+    editor->setScrollBarPosition(scrollBarPosition);
 }
 


### PR DESCRIPTION
Сделано атомарная обработка для форматирования в Code

1. Код обработки мягких переносов соединен с форматированием в Code в одно атомарное действие.
2. Сделано возвращение позиции ScrollBar редактора на то, которое было до обработки мягких переносов. Это предотвращает скачки области обработки текста редактора.


Сергей, пришлите мне, пожалуйста, тот **html** текст (**полный**), на котором форматирование в код не происходит. Я отскриншотил часть этого текста с Вашего видео на Ютуб, распознал скриншот в текст, поэкспериментировал на нем - все работает, все форматируется в код. 
По-видимому, нужная часть текста как раз и не попала в Ваш видео ролик - та, что идет сразу после проблемного места.