### PR TITLE
Улучшена работа кнопок цвета шрифта и выделения текста.

### DIFF
--- a/app/src/libraries/wyedit/Editor.cpp
+++ b/app/src/libraries/wyedit/Editor.cpp
@@ -298,7 +298,9 @@ void Editor::setupSignals(void)
   connect(textArea,               &EditorTextArea::currentCharFormatChanged,
           editorToolBarAssistant, &EditorToolBarAssistant::onChangeIconBackgroundColor,
           Qt::DirectConnection);
-
+  connect(textArea,                 &EditorTextArea::cursorPositionChanged,
+          editorToolBarAssistant,   &EditorToolBarAssistant::onCursorPositionChanged,
+          Qt::DirectConnection);
 
   connect(this,                   &Editor::changeFontselectOnDisplay,
           editorToolBarAssistant, &EditorToolBarAssistant::onChangeFontselectOnDisplay,

--- a/app/src/libraries/wyedit/EditorToolBarAssistant.cpp
+++ b/app/src/libraries/wyedit/EditorToolBarAssistant.cpp
@@ -264,6 +264,17 @@ void EditorToolBarAssistant::onChangeIconBackgroundColor(const QTextCharFormat &
 }
 
 
+// Слот, вызываемый при изменение позиции курсора
+void EditorToolBarAssistant::onCursorPositionChanged()
+{
+    // Изменение цвета иконки выделения фона текста при изменении позиции курсора
+    QColor color = textArea->currentCharFormat().background().color();
+
+    // Вызывается слот "Изменение цвета иконки выделения фона текста"
+    onChangeBackgroundColor(color);
+}
+
+
 // Слот обновления подсветки кнопок выравнивания текста
 // Если параметр activate=false, все кнопки будут выставлены в неактивные
 // Если параметр activate=true, будет подсвечена кнопка, соответсвующая текущему форматированию

--- a/app/src/libraries/wyedit/EditorToolBarAssistant.cpp
+++ b/app/src/libraries/wyedit/EditorToolBarAssistant.cpp
@@ -147,12 +147,24 @@ void EditorToolBarAssistant::onChangeFontcolor(const QColor &color)
 {
     // TRACELOG
 
+    // Формат символов под курсором
+    QTextCharFormat format = textArea->currentCharFormat();
+
+    // Есть ли цвет шрифта под курсором
+    bool hasForegroundColor = format.hasProperty(QTextFormat::ForegroundBrush);
+
+    // Размер иконки для кнопки на панеле инструментов
     QPixmap pix(getIconSize());
-    // Если цвет правильный
-    if(color.isValid())
+
+    // Если есть ли цвет текста под курсором и цвет правильный
+    if(hasForegroundColor && color.isValid())
         pix.fill(color);
     else
-        pix.fill(QApplication::palette().foreground().color());
+    {
+        // Если нет цвета шрифта, то за цвет берется цвет foreground редактора textArea (QTextEdit)
+        // (это позволяет учитывать также цвет шрифта, заданный в файле stylesheet.css)
+        pix.fill(textArea->palette().foreground().color());
+    }
     fontColor->setIcon(pix);
 }
 
@@ -170,12 +182,24 @@ void EditorToolBarAssistant::onChangeBackgroundColor(const QColor &color)
 {
     // TRACELOG
 
+    // Формат символов под курсором
+    QTextCharFormat format = textArea->currentCharFormat();
+
+    // Есть ли цвет фона под курсором
+    bool hasBackgroundColor = format.hasProperty(QTextFormat::BackgroundBrush);
+
+    // Размер иконки для кнопки на панеле инструментов
     QPixmap pix(getIconSize());
-    // Если цвет правильный
-    if(color.isValid())
+
+    // Если есть ли цвет фона под курсором и цвет правильный
+    if(hasBackgroundColor && color.isValid())
         pix.fill(color);
     else
-        pix.fill(QApplication::palette().background().color());
+    {
+        // Если нет цвета фона, то за цвет берется цвет background редактора textArea (QTextEdit)
+        // (это позволяет учитывать также цвет фона, заданный в файле stylesheet.css)
+        pix.fill(textArea->palette().background().color());
+    }
     backgroundColor->setIcon(pix);
 }
 

--- a/app/src/libraries/wyedit/EditorToolBarAssistant.h
+++ b/app/src/libraries/wyedit/EditorToolBarAssistant.h
@@ -72,6 +72,7 @@ public slots:
   void onChangeIconFontColor(const QTextCharFormat &format);
   void onChangeBackgroundColor(const QColor &color);
   void onChangeIconBackgroundColor(const QTextCharFormat &format);
+  void onCursorPositionChanged(); // Слот, вызываемый при изменение позиции курсора
 
 protected:
 

--- a/app/src/libraries/wyedit/formatters/TypefaceFormatter.cpp
+++ b/app/src/libraries/wyedit/formatters/TypefaceFormatter.cpp
@@ -1246,11 +1246,22 @@ void TypefaceFormatter::onFontcolorClicked()
 {
     // TRACELOG
 
-    // Текущий цвет возле курсора
-    QColor currentColor=textArea->textColor();
+    // Текущий цвет шрифта возле курсором
+    QColor currentColor = textArea->textColor();
+
+    // Формат символов под курсором
+    QTextCharFormat format = textArea->currentCharFormat();
+
+    // Есть ли цвет шрифта под курсором
+    bool hasForegroundColor = format.hasProperty(QTextFormat::ForegroundBrush);
+
+    // Если нет цвета шрифта, то за цвет берется цвет foreground редактора textArea (QTextEdit)
+    // (это позволяет учитывать также цвет шрифта, заданный в файле stylesheet.css)
+    if(!hasForegroundColor)
+        currentColor = textArea->palette().foreground().color();
 
     // Диалог запроса цвета
-    QColor selectedColor=QColorDialog::getColor(currentColor, editor);
+    QColor selectedColor = QColorDialog::getColor(currentColor, editor);
 
     // Если цвет выбран, и он правильный
     if(selectedColor.isValid())
@@ -1411,11 +1422,22 @@ void TypefaceFormatter::onBackgroundcolorClicked()
 {
     // TRACELOG
 
-    // Текущий цвет фона возле курсора
-    QColor currentColor=textArea->textBackgroundColor();
+    // Текущий цвет фона под курсором
+    QColor currentColor = textArea->textBackgroundColor();
+
+    // Формат символов под курсором
+    QTextCharFormat format = textArea->currentCharFormat();
+
+    // Есть ли цвет фона под курсором
+    bool hasBackgroundColor = format.hasProperty(QTextFormat::BackgroundBrush);
+
+    // Если нет цвета фона, то за цвет берется цвет background редактора textArea (QTextEdit)
+    // (это позволяет учитывать также цвет фона, заданный в файле stylesheet.css)
+    if(!hasBackgroundColor)
+        currentColor = textArea->palette().background().color();
 
     // Диалог запроса цвета
-    QColor selectedColor=QColorDialog::getColor(currentColor, editor);
+    QColor selectedColor = QColorDialog::getColor(currentColor, editor);
 
     // Если цвет выбран, и он правильный
     if(selectedColor.isValid())


### PR DESCRIPTION
1. Цвет кнопки выбора цвета фона текста отражает цвет фона текста возле
курсора, или - цвет background редактора textArea (QTextEdit).
2. Если в stylesheet.css будет задан цвет фона редактора по-умолчанию
(например, `background-color: rgb(199, 215, 109)`), то при отсутствии
выделения текста цветом иконка кнопки будет иметь цвет background-color
из stylesheet.css, и при входе в диалог выбора цвета выделения цвет
background-color делается активным.
3. Цвет кнопки выбора цвета шрифта отражает цвет текста возле курсора,
или - цвет foreground редактора textArea (QTextEdit).
4. Если в stylesheet.css будет задан цвет шрифта редактора по-умолчанию
(например, `color: blue`), то при отсутствии выбора цвета шрифта
пользователем иконка кнопки будет иметь цвет foreground-color из
stylesheet.css, и при входе в диалог выбора цвета шрифта цвет
foreground-color делается активным.