### PR TITLE
Изменен диалог создания/правки математической формулы

### DIFF
--- a/app/app.pro
+++ b/app/app.pro
@@ -241,7 +241,8 @@ HEADERS = src/main.h \
     src/libraries/wyedit/mvc/views/editorToolbarSettings/EditorToolbarAvailableCommandsView.h \
     src/libraries/wyedit/mvc/controllers/editorToolbarSettings/EditorToolbarUsedCommandsController.h \
     src/libraries/wyedit/mvc/controllers/editorToolbarSettings/EditorToolbarAvailableCommandsController.h \
-    src/libraries/wyedit/EditorConfigToolbars.h
+    src/libraries/wyedit/EditorConfigToolbars.h \
+    src/libraries/wyedit/EditorMathExpressionDialog.h
 
 lessThan(QT_MAJOR_VERSION,5) {
 HEADERS+=src/libraries/qtSingleApplication/qtsingleapplication.h \
@@ -378,7 +379,8 @@ SOURCES = src/main.cpp \
     src/libraries/wyedit/mvc/views/editorToolbarSettings/EditorToolbarAvailableCommandsView.cpp \
     src/libraries/wyedit/mvc/controllers/editorToolbarSettings/EditorToolbarUsedCommandsController.cpp \
     src/libraries/wyedit/mvc/controllers/editorToolbarSettings/EditorToolbarAvailableCommandsController.cpp \
-    src/libraries/wyedit/EditorConfigToolbars.cpp
+    src/libraries/wyedit/EditorConfigToolbars.cpp \
+    src/libraries/wyedit/EditorMathExpressionDialog.cpp
 
 lessThan(QT_MAJOR_VERSION,5) {
 SOURCES+=src/libraries/qtSingleApplication/qtsingleapplication.cpp \

--- a/app/bin/mytetra.qrc
+++ b/app/bin/mytetra.qrc
@@ -119,5 +119,7 @@
         <file>resource/pic/edit_strikeout.svg</file>
         <file>resource/pic/move_left.svg</file>
         <file>resource/pic/move_right.svg</file>
+        <file>resource/pic/edit_zoom-in.svg</file>
+        <file>resource/pic/edit_zoom-out.svg</file>
     </qresource>
 </RCC>

--- a/app/bin/resource/pic/edit_zoom-in.svg
+++ b/app/bin/resource/pic/edit_zoom-in.svg
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://web.resource.org/cc/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" inkscape:export-ydpi="240.00000" inkscape:export-xdpi="240.00000" inkscape:export-filename="/home/jimmac/gfx/novell/pdes/trunk/docs/BIGmime-text.png" sodipodi:docname="zoom-in.svg" sodipodi:docbase="/home/lapo/Icone/cvs/gnome-icon-theme/scalable/actions" inkscape:version="0.44" sodipodi:version="0.32" id="svg249" height="48.000000px" width="48.000000px" inkscape:output_extension="org.inkscape.output.svg.inkscape">
+  <defs id="defs3">
+    <linearGradient inkscape:collect="always" id="linearGradient23434">
+      <stop style="stop-color:#2e3436" offset="0" id="stop23436"/>
+      <stop style="stop-color:#555753" offset="1" id="stop23438"/>
+    </linearGradient>
+    <linearGradient inkscape:collect="always" id="linearGradient19914">
+      <stop style="stop-color:#000000;stop-opacity:1;" offset="0" id="stop19916"/>
+      <stop style="stop-color:#000000;stop-opacity:0;" offset="1" id="stop19918"/>
+    </linearGradient>
+    <linearGradient inkscape:collect="always" id="linearGradient19900">
+      <stop style="stop-color:#888a85" offset="0" id="stop19902"/>
+      <stop style="stop-color:#d3d7cf" offset="1" id="stop19904"/>
+    </linearGradient>
+    <linearGradient id="linearGradient15493">
+      <stop style="stop-color:#eeeeec;stop-opacity:1;" offset="0" id="stop15495"/>
+      <stop style="stop-color:#ffffff;stop-opacity:1" offset="1" id="stop15497"/>
+    </linearGradient>
+    <linearGradient inkscape:collect="always" id="linearGradient11102">
+      <stop style="stop-color:#ffffff;stop-opacity:1;" offset="0" id="stop11104"/>
+      <stop style="stop-color:#ffffff;stop-opacity:0;" offset="1" id="stop11106"/>
+    </linearGradient>
+    <linearGradient inkscape:collect="always" id="linearGradient4952">
+      <stop style="stop-color:#ffffff;stop-opacity:1;" offset="0" id="stop4954"/>
+      <stop style="stop-color:#ffffff;stop-opacity:0;" offset="1" id="stop4956"/>
+    </linearGradient>
+    <linearGradient inkscape:collect="always" id="linearGradient4931">
+      <stop style="stop-color:#babdb6;stop-opacity:1;" offset="0" id="stop4933"/>
+      <stop style="stop-color:#888a85" offset="1" id="stop4935"/>
+    </linearGradient>
+    <linearGradient id="linearGradient4919">
+      <stop style="stop-color:#429eff;stop-opacity:1;" offset="0" id="stop4921"/>
+      <stop style="stop-color:#0044a7;stop-opacity:1;" offset="1" id="stop4923"/>
+    </linearGradient>
+    <linearGradient inkscape:collect="always" id="linearGradient2980">
+      <stop style="stop-color:#000000;stop-opacity:1;" offset="0" id="stop2982"/>
+      <stop style="stop-color:#000000;stop-opacity:0;" offset="1" id="stop2984"/>
+    </linearGradient>
+    <linearGradient id="linearGradient2609" inkscape:collect="always">
+      <stop id="stop2611" offset="0" style="stop-color:#ffffff;stop-opacity:1"/>
+      <stop id="stop2613" offset="1" style="stop-color:#eeeeec"/>
+    </linearGradient>
+    <linearGradient id="linearGradient2617">
+      <stop id="stop2619" offset="0" style="stop-color:#fbfbfa;stop-opacity:1;"/>
+      <stop id="stop2621" offset="1" style="stop-color:#d3d7cf"/>
+    </linearGradient>
+    <linearGradient id="linearGradient2690" inkscape:collect="always">
+      <stop id="stop2692" offset="0" style="stop-color:#2e3436"/>
+      <stop id="stop2694" offset="1" style="stop-color:#555753"/>
+    </linearGradient>
+    <linearGradient id="linearGradient2698">
+      <stop id="stop2700" offset="0" style="stop-color:#555753"/>
+      <stop style="stop-color:#a3a5a2;stop-opacity:1;" offset="0.70238096" id="stop2706"/>
+      <stop id="stop2702" offset="1" style="stop-color:#888a85"/>
+    </linearGradient>
+    <radialGradient inkscape:collect="always" xlink:href="#linearGradient2609" id="radialGradient1409" gradientUnits="userSpaceOnUse" gradientTransform="matrix(-3.294293e-16,1.143443,-1.247217,-1.248581e-6,41.735,-54.25682)" cx="45.094624" cy="-2.6936908" fx="45.094624" fy="-2.6936908" r="10.498367"/>
+    <radialGradient inkscape:collect="always" xlink:href="#linearGradient2617" id="radialGradient1411" gradientUnits="userSpaceOnUse" gradientTransform="matrix(4.928248e-11,-1.686609,1.66336,-1.770202e-15,41.65431,111.7396)" cx="59.787472" cy="10.901535" fx="59.787472" fy="10.901535" r="10.55559"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient2698" id="linearGradient1421" gradientUnits="userSpaceOnUse" x1="81.332451" y1="55.106758" x2="82.919647" y2="53.511261"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient2690" id="linearGradient1423" gradientUnits="userSpaceOnUse" x1="81.096306" y1="57.148193" x2="83.629295" y2="54.615208"/>
+    <radialGradient inkscape:collect="always" xlink:href="#linearGradient4919" id="radialGradient4925" cx="17.062258" cy="28.851427" fx="17.062258" fy="28.851427" r="13.5" gradientTransform="matrix(1.459545,-9.027299e-15,-5.118666e-17,1.345339,-7.403138,-10.82184)" gradientUnits="userSpaceOnUse"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient4931" id="linearGradient4937" x1="54.1129" y1="12.846775" x2="50.079948" y2="-3.8813655" gradientUnits="userSpaceOnUse"/>
+    <radialGradient inkscape:collect="always" xlink:href="#linearGradient4952" id="radialGradient4960" cx="16.829521" cy="24.743624" fx="16.829521" fy="24.743624" r="16.924615" gradientTransform="matrix(2.231289,-0.597872,0.530253,1.979013,-30.74857,-16.49764)" gradientUnits="userSpaceOnUse"/>
+    <radialGradient inkscape:collect="always" xlink:href="#linearGradient11102" id="radialGradient11108" cx="8.0402098" cy="9.5280285" fx="8.0402098" fy="9.5280285" r="9.8125" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.946826,-1.897043e-16,1.897043e-16,0.946826,0.469351,0.499261)"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient15493" id="linearGradient17263" gradientUnits="userSpaceOnUse" x1="19" y1="14.875" x2="19.65625" y2="29" gradientTransform="translate(2,-1)"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient19900" id="linearGradient19906" x1="40.25" y1="41" x2="43.0625" y2="38.434578" gradientUnits="userSpaceOnUse" gradientTransform="translate(-1,0)"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient19914" id="linearGradient19920" x1="33.985317" y1="32.045906" x2="37.211494" y2="35.272079" gradientUnits="userSpaceOnUse" gradientTransform="translate(-1,0)"/>
+    <radialGradient inkscape:collect="always" xlink:href="#linearGradient2980" id="radialGradient23426" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,0,0,0.34,1.362626e-15,19.89607)" cx="28.284271" cy="30.145554" fx="28.284271" fy="30.145554" r="13.258252"/>
+    <radialGradient inkscape:collect="always" xlink:href="#linearGradient2980" id="radialGradient23432" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,-4.196543e-16,-3.619011e-17,0.34,1.860387e-15,19.89607)" cx="28.284271" cy="30.145554" fx="28.284271" fy="30.145554" r="13.258252"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient23434" id="linearGradient23440" x1="55.878288" y1="12.472493" x2="52.5" y2="-4.6213989" gradientUnits="userSpaceOnUse"/>
+  </defs>
+  <g inkscape:groupmode="layer" id="layer6" inkscape:label="Shadow"/>
+  <g style="display:inline" inkscape:groupmode="layer" inkscape:label="Base" id="layer1"/>
+  <g inkscape:groupmode="layer" id="layer5" inkscape:label="Text" style="display:inline">
+    <g transform="translate(-12.26513,47.49999)" style="display:inline" inkscape:label="base" id="g2637"/>
+    <path sodipodi:type="arc" style="opacity:0.6;color:#000000;fill:url(#radialGradient4925);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible" id="path1425" sodipodi:cx="17.5" sodipodi:cy="18.25" sodipodi:rx="13.5" sodipodi:ry="13.75" d="M 31 18.25 A 13.5 13.75 0 1 1  4,18.25 A 13.5 13.75 0 1 1  31 18.25 z" transform="matrix(1.185185,0,0,1.163637,0.259261,-1.236368)"/>
+    <path style="opacity:0.5;color:#000000;fill:url(#radialGradient4960);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible" d="M 20.430801,3.5 C 11.914639,3.824042 5.1019281,10.849356 5.1019281,19.444373 C 5.1019281,21.861291 6.5050447,24.166163 7.5932363,26.15625 C 7.1211653,20.728065 9.4598537,19.543069 11.012791,20.025177 C 15.724296,21.487861 23.900134,22.817382 32.299922,18.431707 C 35.244588,16.894246 36.961785,20.661175 36.844126,17.275469 C 35.904686,9.4808807 29.114153,3.5000001 21.046301,3.5 C 20.840021,3.5 20.635189,3.492223 20.430801,3.5 z " id="path4939" sodipodi:nodetypes="cscsscsc"/>
+    <path transform="matrix(1.6,0,0,1.6,-63,12.8)" d="M 62.5 4.5 A 10 10 0 1 1  42.5,4.5 A 10 10 0 1 1  62.5 4.5 z" sodipodi:ry="10" sodipodi:rx="10" sodipodi:cy="4.5" sodipodi:cx="52.5" id="path2607" style="color:#000000;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#radialGradient1411);stroke-width:1.87499988;stroke-linecap:round;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible" sodipodi:type="arc"/>
+    <path sodipodi:type="arc" style="opacity:0.04705882;color:#000000;fill:url(#radialGradient23432);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible" id="path23418" sodipodi:cx="28.284271" sodipodi:cy="30.145554" sodipodi:rx="13.258252" sodipodi:ry="4.5078058" d="M 41.542523 30.145554 A 13.258252 4.5078058 0 1 1  15.026019,30.145554 A 13.258252 4.5078058 0 1 1  41.542523 30.145554 z" transform="matrix(0.98756,0.175983,-0.12162,0.682489,11.58742,17.92885)"/>
+    <g transform="matrix(1.544052,0,0,1.536016,-85.57756,-44.44515)" id="g2708">
+      <path style="color:#000000;fill:url(#linearGradient1421);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient1423);stroke-width:0.67653471;stroke-linecap:round;stroke-linejoin:round;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible" d="M 76.796351,49.768459 L 77.443998,53.023634 L 82.625171,58.237128 C 82.817674,58.430832 83.596641,58.55743 84.56811,57.580878 C 85.53958,56.604326 85.463684,55.876998 85.215757,55.627773 L 80.034584,50.419494 L 76.796351,49.768459 z " id="path2682" sodipodi:nodetypes="cczzzcc"/>
+      <path style="opacity:0.19215686;color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999964;stroke-linecap:round;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible" d="M 79.567301,51.320041 C 79.564315,51.331245 79.861402,51.644359 79.32201,52.185023 C 78.782611,52.725686 78.314866,52.559011 78.328524,52.545282 L 78.059375,51.023705 L 79.567301,51.320041 z " id="path2687" sodipodi:nodetypes="csccc"/>
+    </g>
+    <path sodipodi:nodetypes="cczzzcc" id="path17267" d="M 34.284644,33.278595 L 34.90721,36.479814 L 42.406806,44.02859 C 42.77564,44.399843 43.340655,44.246496 44.274502,43.312648 C 45.208352,42.3788 45.449128,41.911353 44.985457,41.44495 L 37.485862,33.90116 L 34.284644,33.278595 z " style="opacity:1;color:#000000;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient19906);stroke-width:0.99999934;stroke-linecap:round;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible"/>
+    <path style="opacity:0.15294118;color:#000000;fill:url(#linearGradient19920);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.67653471;stroke-linecap:round;stroke-linejoin:round;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible" d="M 32.831928,31.491641 C 32.5721,31.57915 32.424582,31.851686 32.494166,32.115648 L 33.50745,37.1077 C 33.532728,37.199365 33.582796,37.282377 33.652205,37.347702 L 41.613723,45.363786 C 41.970537,45.720948 42.509181,45.825341 43.157775,45.699789 C 43.80637,45.574237 44.570165,45.162961 45.37735,44.355775 C 46.177873,43.555254 46.590458,42.839054 46.728396,42.195753 C 46.866334,41.552451 46.742411,40.963513 46.390634,40.611736 L 38.380865,32.643653 C 38.302123,32.566369 38.200751,32.515947 38.091355,32.499652 L 33.121437,31.491641 C 33.026862,31.464506 32.926503,31.464506 32.831928,31.491641 z " id="path19908" sodipodi:nodetypes="cccccsssccccc"/>
+    <path transform="matrix(1.65,0,0,1.65,-65.625,12.575)" d="M 62.5 4.5 A 10 10 0 1 1  42.5,4.5 A 10 10 0 1 1  62.5 4.5 z" sodipodi:ry="10" sodipodi:rx="10" sodipodi:cy="4.5" sodipodi:cx="52.5" id="path2605" style="color:#000000;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#radialGradient1409);stroke-width:0.60606074;stroke-linecap:round;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible" sodipodi:type="arc"/>
+    <path transform="matrix(1.75,0,0,1.75,-70.875,12.125)" d="M 62.5 4.5 A 10 10 0 1 1  42.5,4.5 A 10 10 0 1 1  62.5 4.5 z" sodipodi:ry="10" sodipodi:rx="10" sodipodi:cy="4.5" sodipodi:cx="52.5" id="path2599" style="color:#000000;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient23440);stroke-width:0.57142824;stroke-linecap:round;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible" sodipodi:type="arc"/>
+    <path transform="matrix(1.453172,0,0,1.453175,-55.29154,13.46071)" d="M 62.5 4.5 A 10 10 0 1 1  42.5,4.5 A 10 10 0 1 1  62.5 4.5 z" sodipodi:ry="10" sodipodi:rx="10" sodipodi:cy="4.5" sodipodi:cx="52.5" id="path4927" style="color:#000000;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient4937);stroke-width:0.68814939;stroke-linecap:round;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible" sodipodi:type="arc"/>
+    <path sodipodi:type="arc" style="opacity:0.16078431;color:#000000;fill:url(#radialGradient11108);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible" id="path11092" sodipodi:cx="12.375" sodipodi:cy="12.9375" sodipodi:rx="9.8125" sodipodi:ry="9.8125" d="M 22.1875 12.9375 A 9.8125 9.8125 0 1 1  2.5625,12.9375 A 9.8125 9.8125 0 1 1  22.1875 12.9375 z" transform="matrix(1.324842,0,0,1.324842,4.605084,2.859861)"/>
+    <g id="g1399" style="opacity:0.76078431" transform="translate(-2.905726e-7,1)">
+      <path sodipodi:nodetypes="ccccccccccccc" id="rect8466" d="M 18.5,10.5 L 18.5,16.5 L 12.5,16.5 L 12.5,21.5 L 18.5,21.5 L 18.5,27.5 L 23.5,27.5 L 23.5,21.5 L 29.5,21.5 L 29.5,16.5 L 23.5,16.5 L 23.5,10.5 L 18.5,10.5 z " style="opacity:1;color:#000000;fill:url(#linearGradient17263);fill-opacity:1;fill-rule:nonzero;stroke:#3465a4;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible"/>
+      <path sodipodi:nodetypes="ccccccccccccc" id="rect12861" d="M 19.5,11.5 L 19.5,17.5 L 13.5,17.5 L 13.5,20.5 L 19.5,20.5 L 19.5,26.5 L 22.5,26.5 L 22.5,20.5 L 28.5,20.5 L 28.5,17.5 L 22.5,17.5 L 22.5,11.5 L 19.5,11.5 z " style="opacity:1;color:#000000;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible"/>
+    </g>
+    <path sodipodi:type="arc" style="opacity:0.072;color:#000000;fill:url(#radialGradient23426);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible" id="path2970" sodipodi:cx="28.284271" sodipodi:cy="30.145554" sodipodi:rx="13.258252" sodipodi:ry="4.5078058" d="M 41.542523 30.145554 A 13.258252 4.5078058 0 1 1  15.026019,30.145554 A 13.258252 4.5078058 0 1 1  41.542523 30.145554 z" transform="matrix(1.585832,0,0,1.204644,-19.35411,4.31756)"/>
+  </g>
+</svg>

--- a/app/bin/resource/pic/edit_zoom-out.svg
+++ b/app/bin/resource/pic/edit_zoom-out.svg
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://web.resource.org/cc/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" inkscape:export-ydpi="240.00000" inkscape:export-xdpi="240.00000" inkscape:export-filename="/home/jimmac/gfx/novell/pdes/trunk/docs/BIGmime-text.png" sodipodi:docname="zoom-out.svg" sodipodi:docbase="/home/lapo/Icone/cvs/gnome-icon-theme/scalable/actions" inkscape:version="0.44" sodipodi:version="0.32" id="svg249" height="48.000000px" width="48.000000px" inkscape:output_extension="org.inkscape.output.svg.inkscape">
+  <defs id="defs3">
+    <linearGradient inkscape:collect="always" id="linearGradient23434">
+      <stop style="stop-color:#2e3436" offset="0" id="stop23436"/>
+      <stop style="stop-color:#555753" offset="1" id="stop23438"/>
+    </linearGradient>
+    <linearGradient inkscape:collect="always" id="linearGradient19914">
+      <stop style="stop-color:#000000;stop-opacity:1;" offset="0" id="stop19916"/>
+      <stop style="stop-color:#000000;stop-opacity:0;" offset="1" id="stop19918"/>
+    </linearGradient>
+    <linearGradient inkscape:collect="always" id="linearGradient19900">
+      <stop style="stop-color:#888a85" offset="0" id="stop19902"/>
+      <stop style="stop-color:#d3d7cf" offset="1" id="stop19904"/>
+    </linearGradient>
+    <linearGradient id="linearGradient15493">
+      <stop style="stop-color:#eeeeec;stop-opacity:1;" offset="0" id="stop15495"/>
+      <stop style="stop-color:#ffffff;stop-opacity:1" offset="1" id="stop15497"/>
+    </linearGradient>
+    <linearGradient inkscape:collect="always" id="linearGradient11102">
+      <stop style="stop-color:#ffffff;stop-opacity:1;" offset="0" id="stop11104"/>
+      <stop style="stop-color:#ffffff;stop-opacity:0;" offset="1" id="stop11106"/>
+    </linearGradient>
+    <linearGradient inkscape:collect="always" id="linearGradient4952">
+      <stop style="stop-color:#ffffff;stop-opacity:1;" offset="0" id="stop4954"/>
+      <stop style="stop-color:#ffffff;stop-opacity:0;" offset="1" id="stop4956"/>
+    </linearGradient>
+    <linearGradient inkscape:collect="always" id="linearGradient4931">
+      <stop style="stop-color:#babdb6;stop-opacity:1;" offset="0" id="stop4933"/>
+      <stop style="stop-color:#888a85" offset="1" id="stop4935"/>
+    </linearGradient>
+    <linearGradient id="linearGradient4919">
+      <stop style="stop-color:#429eff;stop-opacity:1;" offset="0" id="stop4921"/>
+      <stop style="stop-color:#0044a7;stop-opacity:1;" offset="1" id="stop4923"/>
+    </linearGradient>
+    <linearGradient inkscape:collect="always" id="linearGradient2980">
+      <stop style="stop-color:#000000;stop-opacity:1;" offset="0" id="stop2982"/>
+      <stop style="stop-color:#000000;stop-opacity:0;" offset="1" id="stop2984"/>
+    </linearGradient>
+    <linearGradient id="linearGradient2609" inkscape:collect="always">
+      <stop id="stop2611" offset="0" style="stop-color:#ffffff;stop-opacity:1"/>
+      <stop id="stop2613" offset="1" style="stop-color:#eeeeec"/>
+    </linearGradient>
+    <linearGradient id="linearGradient2617">
+      <stop id="stop2619" offset="0" style="stop-color:#fbfbfa;stop-opacity:1;"/>
+      <stop id="stop2621" offset="1" style="stop-color:#d3d7cf"/>
+    </linearGradient>
+    <linearGradient id="linearGradient2690" inkscape:collect="always">
+      <stop id="stop2692" offset="0" style="stop-color:#2e3436"/>
+      <stop id="stop2694" offset="1" style="stop-color:#555753"/>
+    </linearGradient>
+    <linearGradient id="linearGradient2698">
+      <stop id="stop2700" offset="0" style="stop-color:#555753"/>
+      <stop style="stop-color:#a3a5a2;stop-opacity:1;" offset="0.70238096" id="stop2706"/>
+      <stop id="stop2702" offset="1" style="stop-color:#888a85"/>
+    </linearGradient>
+    <radialGradient inkscape:collect="always" xlink:href="#linearGradient2609" id="radialGradient1409" gradientUnits="userSpaceOnUse" gradientTransform="matrix(-3.294293e-16,1.143443,-1.247217,-1.248581e-6,41.735,-54.25682)" cx="45.094624" cy="-2.6936908" fx="45.094624" fy="-2.6936908" r="10.498367"/>
+    <radialGradient inkscape:collect="always" xlink:href="#linearGradient2617" id="radialGradient1411" gradientUnits="userSpaceOnUse" gradientTransform="matrix(4.928248e-11,-1.686609,1.66336,-1.770202e-15,41.65431,111.7396)" cx="59.787472" cy="10.901535" fx="59.787472" fy="10.901535" r="10.55559"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient2698" id="linearGradient1421" gradientUnits="userSpaceOnUse" x1="81.332451" y1="55.106758" x2="82.919647" y2="53.511261"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient2690" id="linearGradient1423" gradientUnits="userSpaceOnUse" x1="81.096306" y1="57.148193" x2="83.629295" y2="54.615208"/>
+    <radialGradient inkscape:collect="always" xlink:href="#linearGradient4919" id="radialGradient4925" cx="17.062258" cy="28.851427" fx="17.062258" fy="28.851427" r="13.5" gradientTransform="matrix(1.459545,-9.027299e-15,-5.118666e-17,1.345339,-7.403138,-10.82184)" gradientUnits="userSpaceOnUse"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient4931" id="linearGradient4937" x1="54.1129" y1="12.846775" x2="50.079948" y2="-3.8813655" gradientUnits="userSpaceOnUse"/>
+    <radialGradient inkscape:collect="always" xlink:href="#linearGradient4952" id="radialGradient4960" cx="16.829521" cy="24.743624" fx="16.829521" fy="24.743624" r="16.924615" gradientTransform="matrix(2.231289,-0.597872,0.530253,1.979013,-30.74857,-16.49764)" gradientUnits="userSpaceOnUse"/>
+    <radialGradient inkscape:collect="always" xlink:href="#linearGradient11102" id="radialGradient11108" cx="8.0402098" cy="9.5280285" fx="8.0402098" fy="9.5280285" r="9.8125" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.946826,-1.897043e-16,1.897043e-16,0.946826,0.469351,0.499261)"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient15493" id="linearGradient17263" gradientUnits="userSpaceOnUse" x1="19" y1="14.875" x2="19.65625" y2="29" gradientTransform="translate(2,-1)"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient19900" id="linearGradient19906" x1="40.25" y1="41" x2="43.0625" y2="38.434578" gradientUnits="userSpaceOnUse" gradientTransform="translate(-1,0)"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient19914" id="linearGradient19920" x1="33.985317" y1="32.045906" x2="37.211494" y2="35.272079" gradientUnits="userSpaceOnUse" gradientTransform="translate(-1,0)"/>
+    <radialGradient inkscape:collect="always" xlink:href="#linearGradient2980" id="radialGradient23426" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,0,0,0.34,1.362626e-15,19.89607)" cx="28.284271" cy="30.145554" fx="28.284271" fy="30.145554" r="13.258252"/>
+    <radialGradient inkscape:collect="always" xlink:href="#linearGradient2980" id="radialGradient23432" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,-4.196543e-16,-3.619011e-17,0.34,1.860387e-15,19.89607)" cx="28.284271" cy="30.145554" fx="28.284271" fy="30.145554" r="13.258252"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient23434" id="linearGradient23440" x1="55.878288" y1="12.472493" x2="52.5" y2="-4.6213989" gradientUnits="userSpaceOnUse"/>
+  </defs>
+  <g inkscape:groupmode="layer" id="layer6" inkscape:label="Shadow"/>
+  <g style="display:inline" inkscape:groupmode="layer" inkscape:label="Base" id="layer1"/>
+  <g inkscape:groupmode="layer" id="layer5" inkscape:label="Text" style="display:inline">
+    <g transform="translate(-12.26513,47.49999)" style="display:inline" inkscape:label="base" id="g2637"/>
+    <path sodipodi:type="arc" style="opacity:0.6;color:#000000;fill:url(#radialGradient4925);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible" id="path1425" sodipodi:cx="17.5" sodipodi:cy="18.25" sodipodi:rx="13.5" sodipodi:ry="13.75" d="M 31 18.25 A 13.5 13.75 0 1 1  4,18.25 A 13.5 13.75 0 1 1  31 18.25 z" transform="matrix(1.185185,0,0,1.163637,0.259261,-1.236368)"/>
+    <path style="opacity:0.5;color:#000000;fill:url(#radialGradient4960);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible" d="M 20.430801,3.5 C 11.914639,3.824042 5.1019281,10.849356 5.1019281,19.444373 C 5.1019281,21.861291 6.5050447,24.166163 7.5932363,26.15625 C 7.1211653,20.728065 9.4598537,19.543069 11.012791,20.025177 C 15.724296,21.487861 23.900134,22.817382 32.299922,18.431707 C 35.244588,16.894246 36.961785,20.661175 36.844126,17.275469 C 35.904686,9.4808807 29.114153,3.5000001 21.046301,3.5 C 20.840021,3.5 20.635189,3.492223 20.430801,3.5 z " id="path4939" sodipodi:nodetypes="cscsscsc"/>
+    <path transform="matrix(1.6,0,0,1.6,-63,12.8)" d="M 62.5 4.5 A 10 10 0 1 1  42.5,4.5 A 10 10 0 1 1  62.5 4.5 z" sodipodi:ry="10" sodipodi:rx="10" sodipodi:cy="4.5" sodipodi:cx="52.5" id="path2607" style="color:#000000;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#radialGradient1411);stroke-width:1.87499988;stroke-linecap:round;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible" sodipodi:type="arc"/>
+    <path sodipodi:type="arc" style="opacity:0.04705882;color:#000000;fill:url(#radialGradient23432);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible" id="path23418" sodipodi:cx="28.284271" sodipodi:cy="30.145554" sodipodi:rx="13.258252" sodipodi:ry="4.5078058" d="M 41.542523 30.145554 A 13.258252 4.5078058 0 1 1  15.026019,30.145554 A 13.258252 4.5078058 0 1 1  41.542523 30.145554 z" transform="matrix(0.98756,0.175983,-0.12162,0.682489,11.58742,17.92885)"/>
+    <g transform="matrix(1.544052,0,0,1.536016,-85.57756,-44.44515)" id="g2708">
+      <path style="color:#000000;fill:url(#linearGradient1421);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient1423);stroke-width:0.67653471;stroke-linecap:round;stroke-linejoin:round;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible" d="M 76.796351,49.768459 L 77.443998,53.023634 L 82.625171,58.237128 C 82.817674,58.430832 83.596641,58.55743 84.56811,57.580878 C 85.53958,56.604326 85.463684,55.876998 85.215757,55.627773 L 80.034584,50.419494 L 76.796351,49.768459 z " id="path2682" sodipodi:nodetypes="cczzzcc"/>
+      <path style="opacity:0.19215686;color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999964;stroke-linecap:round;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible" d="M 79.567301,51.320041 C 79.564315,51.331245 79.861402,51.644359 79.32201,52.185023 C 78.782611,52.725686 78.314866,52.559011 78.328524,52.545282 L 78.059375,51.023705 L 79.567301,51.320041 z " id="path2687" sodipodi:nodetypes="csccc"/>
+    </g>
+    <path sodipodi:nodetypes="cczzzcc" id="path17267" d="M 34.284644,33.278595 L 34.90721,36.479814 L 42.406806,44.02859 C 42.77564,44.399843 43.340655,44.246496 44.274502,43.312648 C 45.208352,42.3788 45.449128,41.911353 44.985457,41.44495 L 37.485862,33.90116 L 34.284644,33.278595 z " style="opacity:1;color:#000000;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient19906);stroke-width:0.99999934;stroke-linecap:round;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible"/>
+    <path style="opacity:0.15294118;color:#000000;fill:url(#linearGradient19920);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.67653471;stroke-linecap:round;stroke-linejoin:round;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible" d="M 32.831928,31.491641 C 32.5721,31.57915 32.424582,31.851686 32.494166,32.115648 L 33.50745,37.1077 C 33.532728,37.199365 33.582796,37.282377 33.652205,37.347702 L 41.613723,45.363786 C 41.970537,45.720948 42.509181,45.825341 43.157775,45.699789 C 43.80637,45.574237 44.570165,45.162961 45.37735,44.355775 C 46.177873,43.555254 46.590458,42.839054 46.728396,42.195753 C 46.866334,41.552451 46.742411,40.963513 46.390634,40.611736 L 38.380865,32.643653 C 38.302123,32.566369 38.200751,32.515947 38.091355,32.499652 L 33.121437,31.491641 C 33.026862,31.464506 32.926503,31.464506 32.831928,31.491641 z " id="path19908" sodipodi:nodetypes="cccccsssccccc"/>
+    <path transform="matrix(1.65,0,0,1.65,-65.625,12.575)" d="M 62.5 4.5 A 10 10 0 1 1  42.5,4.5 A 10 10 0 1 1  62.5 4.5 z" sodipodi:ry="10" sodipodi:rx="10" sodipodi:cy="4.5" sodipodi:cx="52.5" id="path2605" style="color:#000000;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#radialGradient1409);stroke-width:0.60606074;stroke-linecap:round;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible" sodipodi:type="arc"/>
+    <path transform="matrix(1.75,0,0,1.75,-70.875,12.125)" d="M 62.5 4.5 A 10 10 0 1 1  42.5,4.5 A 10 10 0 1 1  62.5 4.5 z" sodipodi:ry="10" sodipodi:rx="10" sodipodi:cy="4.5" sodipodi:cx="52.5" id="path2599" style="color:#000000;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient23440);stroke-width:0.57142824;stroke-linecap:round;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible" sodipodi:type="arc"/>
+    <path transform="matrix(1.453172,0,0,1.453175,-55.29154,13.46071)" d="M 62.5 4.5 A 10 10 0 1 1  42.5,4.5 A 10 10 0 1 1  62.5 4.5 z" sodipodi:ry="10" sodipodi:rx="10" sodipodi:cy="4.5" sodipodi:cx="52.5" id="path4927" style="color:#000000;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient4937);stroke-width:0.68814939;stroke-linecap:round;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible" sodipodi:type="arc"/>
+    <path sodipodi:type="arc" style="opacity:0.16078431;color:#000000;fill:url(#radialGradient11108);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible" id="path11092" sodipodi:cx="12.375" sodipodi:cy="12.9375" sodipodi:rx="9.8125" sodipodi:ry="9.8125" d="M 22.1875 12.9375 A 9.8125 9.8125 0 1 1  2.5625,12.9375 A 9.8125 9.8125 0 1 1  22.1875 12.9375 z" transform="matrix(1.324842,0,0,1.324842,4.605084,2.859861)"/>
+    <g id="g1399" style="opacity:0.76078431" transform="translate(-2.905726e-7,1)">
+      <path sodipodi:nodetypes="ccccc" id="rect8466" d="M 12.5,16.5 L 12.5,21.5 L 29.5,21.5 L 29.5,16.5 L 12.5,16.5 z " style="opacity:1;color:#000000;fill:url(#linearGradient17263);fill-opacity:1;fill-rule:nonzero;stroke:#3465a4;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible"/>
+      <path sodipodi:nodetypes="ccccc" id="rect12861" d="M 13.5,17.5 L 13.5,20.5 L 28.5,20.5 L 28.5,17.5 L 13.5,17.5 z " style="opacity:1;color:#000000;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible"/>
+    </g>
+    <path sodipodi:type="arc" style="opacity:0.072;color:#000000;fill:url(#radialGradient23426);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible" id="path2970" sodipodi:cx="28.284271" sodipodi:cy="30.145554" sodipodi:rx="13.258252" sodipodi:ry="4.5078058" d="M 41.542523 30.145554 A 13.258252 4.5078058 0 1 1  15.026019,30.145554 A 13.258252 4.5078058 0 1 1  41.542523 30.145554 z" transform="matrix(1.585832,0,0,1.204644,-19.35411,4.31756)"/>
+  </g>
+</svg>

--- a/app/src/libraries/wyedit/EditorConfig.cpp
+++ b/app/src/libraries/wyedit/EditorConfig.cpp
@@ -284,6 +284,24 @@ void EditorConfig::set_tab_size(int i)
 }
 
 
+// -------------------------------------------
+// Счетчик для таймера обновления картинки формулы в редакторе формулы
+// -------------------------------------------
+
+int EditorConfig::getMathExpressionUpdateTime(void)
+{
+    int n = get_parameter("mathExpressionUpdateTime").toInt();
+
+    return n==0 ? 1 : n;
+}
+
+
+void EditorConfig::setMathExpressionUpdateTime(int i)
+{
+    conf->setValue("mathExpressionUpdateTime",i);
+}
+
+
 // -----------------------------
 // Координаты поискового диалога
 // -----------------------------
@@ -396,6 +414,7 @@ void EditorConfig::update_version_process(void)
     parameterFunctions << get_parameter_table_17;
     parameterFunctions << get_parameter_table_18;
     parameterFunctions << get_parameter_table_19;
+    parameterFunctions << get_parameter_table_20;
 
     for(int i=1; i<parameterFunctions.count()-1; ++i)
         if(fromVersion<=i)
@@ -779,6 +798,25 @@ QStringList EditorConfig::get_parameter_table_19(bool withEndSignature)
     return table;
 }
 
+
+QStringList EditorConfig::get_parameter_table_20(bool withEndSignature)
+{
+    // Таблица параметров
+    // Имя, Тип, Значение на случай когда в конфиге параметра прочему-то нет
+    QStringList table;
+
+    // Старые параметры, аналогичные версии 14
+    table << get_parameter_table_19(false);
+
+    // Добавляются новые параметры
+    // время обновления картинки формулы (в секундах)
+    table << "mathExpressionUpdateTime" << "int" << "1";
+
+    if(withEndSignature)
+        table << "0" << "0" << "0";
+
+    return table;
+}
 
 // Метод разрешения конфликтов если исходные и конечные типы не совпадают
 // Должен включать в себя логику обработки только тех параметров

--- a/app/src/libraries/wyedit/EditorConfig.h
+++ b/app/src/libraries/wyedit/EditorConfig.h
@@ -57,6 +57,10 @@ public:
     int get_tab_size(void);
     void set_tab_size(int i);
 
+    // Счетчик для таймера обновления картинки формулы в редакторе формулы
+    int getMathExpressionUpdateTime(void);
+    void setMathExpressionUpdateTime(int i);
+
     QString get_finddialog_geometry(void);
     void set_finddialog_geometry(QString geometry);
 
@@ -102,6 +106,7 @@ private:
     static QStringList get_parameter_table_17(bool withEndSignature=true);
     static QStringList get_parameter_table_18(bool withEndSignature=true);
     static QStringList get_parameter_table_19(bool withEndSignature=true);
+    static QStringList get_parameter_table_20(bool withEndSignature=true);
 
     static QStringList remove_option(QStringList table, QString optionName);
 

--- a/app/src/libraries/wyedit/EditorConfigMisc.cpp
+++ b/app/src/libraries/wyedit/EditorConfigMisc.cpp
@@ -54,6 +54,15 @@ void EditorConfigMisc::setupUi(void)
  tabStopDistanceSpinBox->setMaximum(50);
  tabStopDistanceSpinBox->setValue(conf->get_tab_size());
 
+ // Счетчик для таймера обновления картинки формулы в редакторе формулы
+ updateFormulaTimeLabel = new QLabel(tr("Formula update timer"), this);
+ updateFormulaTimeSecLabel = new QLabel(tr("sec."), this);
+
+ updateFormulaTimeSpinBox = new QSpinBox(this);
+ updateFormulaTimeSpinBox->setMinimum(1);
+ updateFormulaTimeSpinBox->setMaximum(20);
+ updateFormulaTimeSpinBox->setValue(conf->getMathExpressionUpdateTime());
+
  // Кнопка редактирования файла конфигурации WyEdit
  editWyEditConfigFile=new QPushButton(this);
  editWyEditConfigFile->setText(tr("Edit config file"));
@@ -73,13 +82,18 @@ void EditorConfigMisc::assembly(void)
   // Сборка всех блоков настройки отступа в окно
   QGridLayout *configLayout=new QGridLayout();
   configLayout->addWidget(indentStepLabel,   0, 0);
-  configLayout->addWidget(indentStep,         0, 1);
+  configLayout->addWidget(indentStep,        0, 1);
   configLayout->addWidget(indentStepFlexion, 0, 2);
 
   // Компановка контролов "Шаг дистанции для клавиши Tab"
   configLayout->addWidget(tabStopDistanceLabel,         1, 0);
   configLayout->addWidget(tabStopDistanceSpinBox,       1, 1);
   configLayout->addWidget(tabStopDistanceFlexionLabel,  1, 2);
+
+  // Компановка контролов Счетчика для таймера обновления картинки формулы в редакторе формулы
+  configLayout->addWidget(updateFormulaTimeLabel,    2, 0);
+  configLayout->addWidget(updateFormulaTimeSpinBox,  2, 1);
+  configLayout->addWidget(updateFormulaTimeSecLabel, 2, 2);
 
   // Группировщик виджетов для опасной зоны
   QGroupBox *dangerBox=new QGroupBox(this);
@@ -126,6 +140,11 @@ int EditorConfigMisc::applyChanges(void)
  // Если был изменен размер табуляции для клавиши Tab
  if(conf->get_tab_size()!=tabStopDistanceSpinBox->value()) {
    conf->set_tab_size(tabStopDistanceSpinBox->value());
+ }
+
+ // Если был изменен счетчик для таймера обновления картинки формулы в редакторе формулы
+ if(conf->getMathExpressionUpdateTime()!=updateFormulaTimeSpinBox->value()) {
+   conf->setMathExpressionUpdateTime(updateFormulaTimeSpinBox->value());
  }
  
  return difficultChanges;

--- a/app/src/libraries/wyedit/EditorConfigMisc.h
+++ b/app/src/libraries/wyedit/EditorConfigMisc.h
@@ -36,6 +36,11 @@ private:
   QLabel *tabStopDistanceFlexionLabel;
   QSpinBox *tabStopDistanceSpinBox;
 
+  // Счетчик для таймера обновления картинки формулы в редакторе формулы
+  QLabel *updateFormulaTimeLabel;
+  QSpinBox *updateFormulaTimeSpinBox;
+  QLabel *updateFormulaTimeSecLabel;
+
   QPushButton *editWyEditConfigFile;
   
   EditorConfig *conf;

--- a/app/src/libraries/wyedit/EditorMathExpressionDialog.cpp
+++ b/app/src/libraries/wyedit/EditorMathExpressionDialog.cpp
@@ -123,7 +123,7 @@ void EditorMathExpressionDialog::setupUi()
 
     // Прокрутка для картинки формулы
     imageScrollArea = new QScrollArea(this);
-    imageScrollArea->setBackgroundRole(QPalette::Dark);
+    imageScrollArea->setBackgroundRole(QPalette::Light);
     imageScrollArea->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
     imageScrollArea->setHorizontalScrollBarPolicy(Qt::ScrollBarAsNeeded);
     imageScrollArea->setWidget(imageLabel);

--- a/app/src/libraries/wyedit/EditorMathExpressionDialog.cpp
+++ b/app/src/libraries/wyedit/EditorMathExpressionDialog.cpp
@@ -1,0 +1,368 @@
+#include "EditorMathExpressionDialog.h"
+#include <QFile>
+#include <QScrollBar>
+
+#include "EditorConfig.h"
+#include "main.h"
+#include "views/mainWindow/MainWindow.h"
+
+/******************************************************************
+ *                      Диалог написания Tex формулы              *
+ * ****************************************************************/
+
+EditorMathExpressionDialog::EditorMathExpressionDialog(MathExpressionFormatter *mathExpressionFormatter, QWidget *parent) : QDialog(parent)
+{
+    // Период обновления картинки по таймеру (сек.)
+    EditorConfig *conf = find_object<EditorConfig>("editorconfig");
+    mathExpressionUpdateTime = conf->getMathExpressionUpdateTime();
+
+    // Инициализация диалога
+    setupUi();
+    setupSignals();
+    assembly();
+
+    // Надо ли масштабировать картинку до размеров ScrollArea
+    fitToScrollArea = fitToScrollAreaCheckBox->isChecked();
+
+    // Задание размеров диалога
+    setMinimumHeight(
+        int( 0.5 * static_cast<double>(find_object<MainWindow>("mainwindow")->height()) )
+    );
+    setMinimumWidth(
+        int( 0.5 * static_cast<double>(find_object<MainWindow>("mainwindow")->width()) )
+    );
+    resize(QGuiApplication::primaryScreen()->availableSize() / 2);
+
+    // Класс для работы с математическими выражениями
+    this->mathExpressionFormatter = mathExpressionFormatter;
+
+    // Признак, было ли изменение формулы во время простоя таймера
+    formulaModifiedTimePeriod = false;
+
+    // Фокус - на контроле ввода текста формулы
+    textArea->setFocus();
+
+    // Запуск таймера с периодичностью, взятой из файла конфигурации
+    onStartTimer();
+}
+
+EditorMathExpressionDialog::~EditorMathExpressionDialog()
+{
+    if (textArea!=nullptr) {
+        delete textArea;
+    }
+}
+
+
+void EditorMathExpressionDialog::setMathExpressionText(QString text)
+{
+    textArea->setPlainText(text);
+}
+
+QString EditorMathExpressionDialog::getMathExpressionText()
+{
+    return textArea->toPlainText();
+}
+
+// Был ли изменен текст, показанный в диалоге
+bool EditorMathExpressionDialog::isModified()
+{
+    return textArea->document()->isModified();
+}
+
+void EditorMathExpressionDialog::setWordWrapMode(QTextOption::WrapMode mode)
+{
+    textArea->setWordWrapMode(mode);
+}
+
+
+void EditorMathExpressionDialog::showEvent(QShowEvent *event)
+{
+    // Первая отрисовка картинки формулы
+    updateFormulaPicture();
+
+    QDialog::showEvent(event);
+}
+
+void EditorMathExpressionDialog::setupUi()
+{
+    // Таймер для отрисовки картинки формулы
+    timer = new QTimer(this);
+
+    /* Зона всех контролов */
+    // Виджет для сборки всех контролов по работе с картинкой формулы
+    topWidget = new QWidget(this);
+    // Виджет для сборки всех контролов по работе с текстом формулы
+    bottomWidget = new QWidget(this);
+
+
+    // Разделитель области написания формулы от области отображения формулы в графическом виде
+    mathSplitter = new QSplitter(Qt::Orientation::Vertical, this);
+    mathSplitter->setBackgroundRole(QPalette::Mid);
+    //mathSplitter->setHandleWidth(5);
+
+
+    /* Область работы с картинкой формулы */
+    // Метка, обозначающая зону отображения картинки формулы
+    pictureFormalaLabel = new QLabel(tr("Picture formula"), this);
+
+    // Масштабирование картинки до размеров ScrollArea
+    fitToScrollAreaCheckBox = new QCheckBox(tr("Fit to scroll area"), this);
+    fitToScrollAreaCheckBox->setChecked(true);
+
+    // Переключатели обновления картинки: по таймеру или в реальном времени
+    timerRadioButton = new QRadioButton(tr("Timer update (%1) sec.").arg(mathExpressionUpdateTime), this);
+    timerRadioButton->setChecked(true);
+    realTimeRadioButton = new QRadioButton(tr("Real time update"), this);
+
+    // Метка для отображения картинки формулы
+    imageLabel = new QLabel(this);
+    imageLabel->setBackgroundRole(QPalette::Base);
+    imageLabel->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Ignored);
+    imageLabel->setScaledContents(true);
+
+    // Прокрутка для картинки формулы
+    imageScrollArea = new QScrollArea(this);
+    imageScrollArea->setBackgroundRole(QPalette::Dark);
+    imageScrollArea->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
+    imageScrollArea->setHorizontalScrollBarPolicy(Qt::ScrollBarAsNeeded);
+    imageScrollArea->setWidget(imageLabel);
+
+
+    /* Область работы с текстом формулы */
+    // Текстовая область для написания формулы
+    textArea = new TexTextEdit();
+    textArea->setAcceptRichText(false);
+    textArea->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+
+    // Формирование зоны контролов масштабирования области написания текста формулы
+    textFormalaLabel = new QLabel(tr("Formula text"), this);
+
+    textFormulaZoomInPushButton = new QToolButton(this);
+    textFormulaZoomInPushButton->setIcon(QIcon(":/resource/pic/edit_zoom-in.svg"));
+    textFormulaZoomInPushButton->setToolTip(tr("Zoom in"));
+
+    textFormulaZoomOutPushButton = new QToolButton(this);
+    textFormulaZoomOutPushButton->setIcon(QIcon(":/resource/pic/edit_zoom-out.svg"));
+    textFormulaZoomOutPushButton->setToolTip(tr("Zoom out"));
+
+
+    // Создание набора диалоговых кнопок
+    dialogButtonBox = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, this);
+}
+
+void EditorMathExpressionDialog::setupSignals()
+{
+    // Масштабирование картинки до размеров ScrollArea
+    connect(fitToScrollAreaCheckBox, &QCheckBox::clicked, this, &EditorMathExpressionDialog::onFitToScrollArea);
+
+    // Увеличение масштаба области текста формулы
+    connect(textFormulaZoomInPushButton, &QPushButton::clicked, this, &EditorMathExpressionDialog::onTextZoomIn);
+
+    // Уменьшение масштаба области текста формулы
+    connect(textFormulaZoomOutPushButton, &QPushButton::clicked, this, &EditorMathExpressionDialog::onTextZoomOut);
+
+    // Масштабирование картинки формулы при перемещении разделителя
+    connect(mathSplitter, &QSplitter::splitterMoved, this, &EditorMathExpressionDialog::onPictureZoom);
+
+    // Установка флага изменения формулы при наборе символов
+    connect(textArea, &QTextEdit::textChanged, this, &EditorMathExpressionDialog::onTextChanged);
+
+    // Обработка undo и redo в редакторе формулы - перерисовка картинки
+    connect(textArea, &TexTextEdit::isUndo, this, &EditorMathExpressionDialog::onUndo);
+    connect(textArea, &TexTextEdit::isRedo, this, &EditorMathExpressionDialog::onRedo);
+
+    // Переключатели обновления картинки: по таймеру или в реальном времени (включение или отключение таймера)
+    connect(timerRadioButton, &QRadioButton::clicked, this, &EditorMathExpressionDialog::onStartTimer);
+    connect(realTimeRadioButton, &QRadioButton::clicked, this, &EditorMathExpressionDialog::onStopTimer);
+
+    // Обработка кнопки OK
+    connect(dialogButtonBox, &QDialogButtonBox::accepted, this, &EditorMathExpressionDialog::accept);
+
+    // Обработка кнопки Cancel
+    connect(dialogButtonBox, &QDialogButtonBox::rejected, this, &EditorMathExpressionDialog::reject);
+
+    // Подключение таймера
+    connect(timer, &QTimer::timeout, this, &EditorMathExpressionDialog::onTimerAlarm);
+}
+
+void EditorMathExpressionDialog::assembly()
+{
+    /* Формирование области контролов масштабирования работы с картинкой формулы */
+    // Область контролов по работе с картинкой
+    pictureFormulaControlLayout = new QHBoxLayout();
+    pictureFormulaControlLayout->addWidget(pictureFormalaLabel);
+    pictureFormulaControlLayout->addStretch();
+    pictureFormulaControlLayout->addWidget(timerRadioButton);
+    pictureFormulaControlLayout->addWidget(realTimeRadioButton);
+    pictureFormulaControlLayout->addStretch();
+    pictureFormulaControlLayout->addWidget(fitToScrollAreaCheckBox);
+
+    // Область работы с картинкой формулы
+    pictureFormulaLayout = new QVBoxLayout();
+    pictureFormulaLayout->setMargin(5);
+    pictureFormulaLayout->addLayout(pictureFormulaControlLayout);
+    pictureFormulaLayout->addWidget(imageScrollArea);
+
+    // Сборка на виджет всех контролом по работе с текстом формулы
+    topWidget->setLayout(pictureFormulaLayout);
+
+
+    /* Формирование области контролов масштабирования работы с текстом формулы */
+    // Компоновка контролов масштабирования текста формулы
+    textFormulaZoomLayout = new QHBoxLayout();
+    textFormulaZoomLayout->addWidget(textFormalaLabel);
+    textFormulaZoomLayout->addStretch(1);
+    textFormulaZoomLayout->addWidget(textFormulaZoomInPushButton);
+    textFormulaZoomLayout->addWidget(textFormulaZoomOutPushButton);
+
+    // Область работы с текстом формулы
+    textFormulaLayout = new QVBoxLayout();
+    textFormulaLayout->setMargin(5);
+    textFormulaLayout->addLayout(textFormulaZoomLayout);
+    textFormulaLayout->addWidget(textArea);
+
+    // Сборка на виджет всех контролов по работе с текстом формулы
+    bottomWidget->setLayout(textFormulaLayout);
+
+    // Сборка всех контролов на разделитель
+    mathSplitter->addWidget(topWidget);
+    mathSplitter->addWidget(bottomWidget);
+
+    /* Сборка всех контролов */
+    QVBoxLayout *mainLayout = new QVBoxLayout(this);
+    mainLayout->setMargin(5);
+
+    // Добавление разделителя основных виджетов
+    mainLayout->addWidget(mathSplitter);
+
+    // Добавление box кнопок OK и Cancel
+    mainLayout->addWidget(dialogButtonBox);
+
+    setLayout(mainLayout);
+}
+
+
+// Масштабирование картинки до размеров ScrollArea
+void EditorMathExpressionDialog::onFitToScrollArea()
+{
+    fitToScrollArea = fitToScrollAreaCheckBox->isChecked();
+    // Масштабирование картинки формулы при перемещении разделителя
+    onPictureZoom(0,1);
+}
+
+// Увеличение масштаба области текста формулы
+void EditorMathExpressionDialog::onTextZoomIn()
+{
+     textArea->zoomIn(2);
+}
+
+// Уменьшение масштаба области текста формулы
+void EditorMathExpressionDialog::onTextZoomOut()
+{
+    textArea->zoomIn(-2);
+}
+
+// Масштабирование картинки формулы при перемещении разделителя
+void EditorMathExpressionDialog::onPictureZoom(int /*pos*/, int /*index*/)
+{
+    if (fitToScrollArea) {
+        double pixHeight = imageLabel->pixmap()->height();
+        double imageScrollAreaHeight = imageScrollArea->geometry().height();
+        double factor = imageScrollAreaHeight/pixHeight;
+        imageLabel->setFixedWidth(int(factor * imageLabel->pixmap()->width()));
+        imageLabel->setFixedHeight(int(factor * imageLabel->pixmap()->height()));
+    }
+}
+
+// Включение таймера обновления картинки формулы
+void EditorMathExpressionDialog::onStartTimer()
+{
+    timer->start(mathExpressionUpdateTime*1000); // отработка таймера в секундах
+}
+
+// Отключение таймера обновления картинки формулы
+void EditorMathExpressionDialog::onStopTimer()
+{
+    timer->stop();
+}
+
+// Обновление картинки формулы по таймеру
+void EditorMathExpressionDialog::onTimerAlarm()
+{
+    if (textArea->document()->isModified() && formulaModifiedTimePeriod) {
+        // Обновление картинки формулы
+        updateFormulaPicture();
+        // Сброс флага изменения формулы при наборе символов
+        formulaModifiedTimePeriod = false;
+    }
+}
+
+// Изменение картинки при изменении текста (для действий undo/redo редатора формулы)
+void EditorMathExpressionDialog::onTextChanged()
+{
+    if (textArea->document()->isModified()) {
+        // Установка флага изменения формулы при наборе символов
+        formulaModifiedTimePeriod = true;
+    }
+
+    if (realTimeRadioButton->isChecked()) {
+        // Обновление картинки формулы в реальном времени
+        updateFormulaPicture();
+    }
+}
+
+void EditorMathExpressionDialog::onUndo()
+{
+    textArea->undo();
+    // Установка флага изменения формулы при наборе символов
+    formulaModifiedTimePeriod = true;
+    // Обновление картинки формулы
+    updateFormulaPicture();
+}
+
+void EditorMathExpressionDialog::onRedo()
+{
+    textArea->redo();
+    // Установка флага изменения формулы при наборе символов
+    formulaModifiedTimePeriod = true;
+    // Обновление картинки формулы
+    updateFormulaPicture();
+}
+
+// Обновление картинки формулы
+void EditorMathExpressionDialog::updateFormulaPicture()
+{
+    QString tempGifFileName = QDir::tempPath()+"/"+getUniqueId()+".gif";
+    mathExpressionFormatter->createGifFromMathExpression( textArea->toPlainText(), tempGifFileName, false );
+
+    QPixmap currentPixmap(tempGifFileName);
+
+    if (!currentPixmap.isNull()) {
+        // Удаление временного Gif файла картинки
+        if (QFile::exists(tempGifFileName)) {
+            QFile::remove(tempGifFileName);
+        }
+
+        // Замена картинки на новую
+        if (imageLabel!=nullptr) {
+            delete imageLabel;
+        }
+
+        imageLabel = new QLabel(this);
+        imageLabel->setBackgroundRole(QPalette::Base);
+        //imageLabel->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Ignored);
+        imageLabel->setMargin(10);
+        imageLabel->setScaledContents(true);
+        imageLabel->setPixmap(currentPixmap);
+
+        // Добавление метки-картинки в область прокрутки
+        imageScrollArea->setWidget(imageLabel);
+
+        // Масштабирование картинки формулы при перемещении разделителя
+        onPictureZoom(0,1);
+
+        // Автопрокрутка до правого края картинки (последний введенный символ в тексте формулы)
+        imageScrollArea->horizontalScrollBar()->setValue(imageScrollArea->horizontalScrollBar()->maximum());
+    }
+}

--- a/app/src/libraries/wyedit/EditorMathExpressionDialog.h
+++ b/app/src/libraries/wyedit/EditorMathExpressionDialog.h
@@ -22,7 +22,9 @@
  *                      Диалог написания Tex формулы              *
  * ****************************************************************/
 
+// =================================================================
 // Вспомогательный класс-наследник QTextEdit для отлова undo / redo
+// =================================================================
 class TexTextEdit : public QTextEdit
 {
     Q_OBJECT
@@ -46,6 +48,9 @@ signals:
     void isRedo(); // Сообщение о том, что произошло событие redo
 };
 
+// =============================================
+// Основной класс диалога написания Tex формулы
+// =============================================
 class EditorMathExpressionDialog : public QDialog
 {
     Q_OBJECT
@@ -68,17 +73,14 @@ public:
 
 protected slots:
 
-    // Масштабирование картинки до размеров ScrollArea
-    void onFitToScrollArea();
+    // Обработка переключения режима масштабирования картинки формулы
+    void onSwitchFitToScrollArea();
 
     // Увеличение масштаба области текста формулы
     void onTextZoomIn();
 
     // Уменьшение масштаба области текста формулы
     void onTextZoomOut();
-
-    // Масштабирование картинки формулы при перемещении разделителя
-    void onPictureZoom(int /*pos*/, int /*index*/);
 
     // Включение таймера обновления картинки формулы
     void onStartTimer();
@@ -103,6 +105,9 @@ protected:
     // Первая отрисовка картинки формулы
     void showEvent(QShowEvent *event);
 
+    // Масштабирование картинки формулы в зависимости от изменения размеров диалога
+    void resizeEvent(QResizeEvent *event);
+
     void setupUi(void);
     void setupSignals(void);
     void assembly(void);
@@ -111,6 +116,9 @@ private:
 
     // Обновление картинки формулы
     void updateFormulaPicture();
+
+    // Масштабирование картинки формулы
+    void pictureZoom();
 
     // Разделитель областей отображения картинки формулы и написания текста формулы
     QSplitter *mathSplitter;
@@ -123,8 +131,6 @@ private:
     QRadioButton *realTimeRadioButton;          // Обновление картинки формулы в реальном времени
     QCheckBox *fitToScrollAreaCheckBox;         // Масштабирование картинки до размеров ScrollArea
     QVBoxLayout *pictureFormulaLayout;          // Компановщик всех контролов по работе с картинкой формулы
-
-    bool fitToScrollArea;                       // Надо ли масштабировать картинку до размеров ScrollArea
 
     // Область работы с текстом формулы
     QWidget *bottomWidget;  // Виджет, объединяющий все контролы по работе с текстом формулы (для сплитера)

--- a/app/src/libraries/wyedit/EditorMathExpressionDialog.h
+++ b/app/src/libraries/wyedit/EditorMathExpressionDialog.h
@@ -1,0 +1,152 @@
+#ifndef EDITORMATHEXPRESSIONDIALOG_H
+#define EDITORMATHEXPRESSIONDIALOG_H
+
+#include <QWidget>
+#include <QDialog>
+#include <QDialogButtonBox>
+#include <QTimer>
+#include <QSplitter>
+#include <QTextEdit>
+#include <QScrollArea>
+#include <QLabel>
+#include <QHBoxLayout>
+#include <QVBoxLayout>
+#include <QToolButton>
+#include <QCheckBox>
+#include <QRadioButton>
+#include <QKeyEvent>
+
+#include "formatters/MathExpressionFormatter.h"
+
+/******************************************************************
+ *                      Диалог написания Tex формулы              *
+ * ****************************************************************/
+
+// Вспомогательный класс-наследник QTextEdit для отлова undo / redo
+class TexTextEdit : public QTextEdit
+{
+    Q_OBJECT
+public:
+    explicit TexTextEdit(QTextEdit *parent = nullptr) : QTextEdit(parent) {}
+    virtual ~TexTextEdit() {}
+
+protected:
+    void keyPressEvent(QKeyEvent *e) {
+        if (e->modifiers()==Qt::ControlModifier) {
+            if (e->key()==Qt::Key_Z)
+                emit isUndo();
+            if (e->key()==Qt::Key_Y)
+                emit isRedo();
+        }
+        QTextEdit::keyPressEvent(e);
+    }
+
+signals:
+    void isUndo(); // Сообщение о том, что произошло событие undo
+    void isRedo(); // Сообщение о том, что произошло событие redo
+};
+
+class EditorMathExpressionDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+
+    explicit EditorMathExpressionDialog(MathExpressionFormatter *mathExpressionFormatter, QWidget *parent = nullptr);
+    virtual ~EditorMathExpressionDialog();
+
+    // Вставка текста Tex формулы в редактор формулы
+    void setMathExpressionText(QString text);
+
+    // Получение текста Tex формулы из редактора формулы
+    QString getMathExpressionText();
+
+    // Был ли изменен текст формулы, показанный в диалоге
+    bool isModified();
+
+    void setWordWrapMode(QTextOption::WrapMode mode);
+
+protected slots:
+
+    // Масштабирование картинки до размеров ScrollArea
+    void onFitToScrollArea();
+
+    // Увеличение масштаба области текста формулы
+    void onTextZoomIn();
+
+    // Уменьшение масштаба области текста формулы
+    void onTextZoomOut();
+
+    // Масштабирование картинки формулы при перемещении разделителя
+    void onPictureZoom(int /*pos*/, int /*index*/);
+
+    // Включение таймера обновления картинки формулы
+    void onStartTimer();
+
+    // Отключение таймера обновления картинки формулы
+    void onStopTimer();
+
+    // Обновление картинки формулы по таймеру
+    void onTimerAlarm();
+
+    // Установка флага изменения текста формулы при наборе символов
+    void onTextChanged();
+
+    // Перерисовка картинки формулы при действии undo
+    void onUndo();
+
+    // Перерисовка картинки формулы при действии redo
+    void onRedo();
+
+protected:
+
+    // Первая отрисовка картинки формулы
+    void showEvent(QShowEvent *event);
+
+    void setupUi(void);
+    void setupSignals(void);
+    void assembly(void);
+
+private:
+
+    // Обновление картинки формулы
+    void updateFormulaPicture();
+
+    // Разделитель областей отображения картинки формулы и написания текста формулы
+    QSplitter *mathSplitter;
+
+    // Область работы с картинкой формулы
+    QWidget *topWidget; // Виджет, объединяющий все контролы по работе с картинкой формулы (для сплитера)
+    QLabel *pictureFormalaLabel;                // Надпись Picture formula
+    QHBoxLayout *pictureFormulaControlLayout;   // Область контролов по работе с масштабированием картинки
+    QRadioButton *timerRadioButton;             // Обновление картинки формулы по таймеру
+    QRadioButton *realTimeRadioButton;          // Обновление картинки формулы в реальном времени
+    QCheckBox *fitToScrollAreaCheckBox;         // Масштабирование картинки до размеров ScrollArea
+    QVBoxLayout *pictureFormulaLayout;          // Компановщик всех контролов по работе с картинкой формулы
+
+    bool fitToScrollArea;                       // Надо ли масштабировать картинку до размеров ScrollArea
+
+    // Область работы с текстом формулы
+    QWidget *bottomWidget;  // Виджет, объединяющий все контролы по работе с текстом формулы (для сплитера)
+    QLabel *textFormalaLabel;                   // Надпись Formula text
+    QToolButton *textFormulaZoomInPushButton;   // Увеличение масштаба области текста
+    QToolButton *textFormulaZoomOutPushButton;  // Уменьшение масштаба области текста
+    QHBoxLayout *textFormulaZoomLayout;         // Компановщик контролов работы с масштабом текста формулы
+    QVBoxLayout *textFormulaLayout; // Компановщик всех контролов по работе с текстом формулы
+    QLabel *imageLabel;             // Метка для отображения картинки формулы
+    QScrollArea *imageScrollArea;   // Область прокрутки метки
+    TexTextEdit *textArea;          // Текстовая область написания формулы
+
+    bool formulaModifiedTimePeriod; // Признак, было ли изменение формулы во время простоя таймера
+
+    // Кнопки Ok и Cancel
+    QDialogButtonBox *dialogButtonBox;
+
+    // Работа с таймером
+    QTimer *timer;                  // Таймер для отрисовки картинки формулы
+    int mathExpressionUpdateTime;   // Период обновления картинки по таймеру (сек.)
+
+    MathExpressionFormatter *mathExpressionFormatter; // Класс для работы с математическими выражениями
+};
+
+#endif // EDITORMATHEXPRESSIONDIALOG_H

--- a/app/src/libraries/wyedit/formatters/MathExpressionFormatter.h
+++ b/app/src/libraries/wyedit/formatters/MathExpressionFormatter.h
@@ -18,6 +18,8 @@ public:
   QString mathExpressionOnSelect(void);
   QString mathExpressionOnCursor(void);
 
+  void createGifFromMathExpression(QString iMathExpression, QString iFileName, bool removeTeXFileToTrash=true);
+
 signals:
 
 public slots:
@@ -36,7 +38,6 @@ protected:
 
   QString getMathExpressionByImageName(QString resourceImageName);
 
-  void createGifFromMathExpression(QString iMathExpression, QString iFileName);
 };
 
 #endif // MATHEXPRESSIONFORMATTER_H

--- a/app/src/libraries/wyedit/mvc/views/editorToolbarSettings/EditorToolbarSettingsScreen.cpp
+++ b/app/src/libraries/wyedit/mvc/views/editorToolbarSettings/EditorToolbarSettingsScreen.cpp
@@ -74,7 +74,7 @@ void EditorToolbarSettingsScreen::setupUI()
 
     usedCommandDownPushButton = new QPushButton(QIcon(":/resource/pic/move_dn.svg"), "", this);
     usedCommandDownPushButton->setShortcut(QKeySequence("Alt+Down"));
-    // Текущие комманды на панели инструментов
+    // Текущие команды на панели инструментов
     usedCommandsToolbarLabel = new QLabel(tr("Current Toolbar Commands"), this);
 
     // Контроллер списка всех доступных кнопок Редактора Текста


### PR DESCRIPTION
Изменен диалог создания/правки математической формулы.

1. На диалоге создано 2 области:
- область создания/правки формулы (внизу диалога)
- область просмотра картинки формулы (вверху диалога)
2. Области разделены перемещающимся вертикально разделителем.
3. Область создания/правки формулы можно масштабировать кнопками Zoom In и Zoom Out.
4. В диалоге "Настройки редактора" создан контрол для установки периода обновления картинки формулы по таймеру, в секундах.
5. Обновление картинки формулы происходит либо в режиме установленного в диалоге "Настройки редактора" периода для таймера (задано по-умолчанию), либо - в режиме заданного реального времени.
6. Чекбокс "Fit to scroll area" позволяет либо масштабировать картинку в пределах области прокрутки картинки (включено), либо - масштабирование отключено, и картинка "растет" вправо по мере создания формулы.
7. При перемещении разделителя, если чекбокс "Fit to scroll area" включен, то происходит масштабирование картинки в границах области прокрутки картинки.
8. Все временные картинки формулы не переносятся в папку trash, а полностью удаляются. Для этого были внесены изменения в метод createGifFromMathExpression класса MathExpressionFormatter. По-умолчанию метод MathExpressionFormatter работает, как обычно - переносит промежуточные данные по картинкам в папку trash в момент вставки формулы. Но при правке формулы временные картинки и Tex файлы удаляются полностью.
9. Сделано обновление картинки формулы и для undo/redo редактора формул.
10. Минимальные размеры диалога заданы относительно от размеров приложения MyTetra.