### PR TITLE
Устранен баг: падение программы при нажатии кнопки Ok в диалоге Настройки редактора текста

### DIFF
--- a/app/src/libraries/wyedit/EditorConfigToolbars.cpp
+++ b/app/src/libraries/wyedit/EditorConfigToolbars.cpp
@@ -78,5 +78,9 @@ int EditorConfigToolbars::applyChanges(void)
 {
   qDebug() << "Apply changes editor toolbars";
 
-  return toolbuttonsScreen->isNeedRestart() ? 1 : 0;
+  if (toolbuttonsScreen!=nullptr) {
+      // Только, если диалог по работе с командами панелей вызывался
+      return toolbuttonsScreen->isNeedRestart() ? 1 : 0;
+  }
+  return 0;
 }


### PR DESCRIPTION
Устранен баг: падение программы при нажатии кнопки Ok в диалоге Настройки редактора текста, в случае, если диалог настроек кнопок панелей иснструментов редактора текста не вызывался.