### PR TITLE
Компилябельность для windows Qt5.13.2

### DIFF
--- a/app/src/views/consoleEmulator/ExecuteCommand.cpp
+++ b/app/src/views/consoleEmulator/ExecuteCommand.cpp
@@ -100,8 +100,8 @@ void ExecuteCommand::closeProcess(void)
 {
     // Процессы 0 и 1 - это однозначно системные процессы, такого PID быть не может
     // Возможно данное условие поборет проблему [WRN] QIODevice::read (QProcess): device not open
-    if(process->pid()>1) {
-        qDebug() << "Close process, PID" << process->pid();
+    if(process->processId()>1) {
+        qDebug() << "Close process, PID" << process->processId();
         
         process->kill();
         process->terminate();


### PR DESCRIPTION
Помимо того, что теперь сборка под windows работает, есть заметка из документации:

```
Q_PID QProcess::pid() const
This function is obsolete. It is provided to keep old source code working. We strongly advise against using it in new code.
Use processId() instead.
```