### PR TITLE
fix for build with msvc, replace and/or with &&/||

### DIFF
--- a/app/src/libraries/crypt/Password.cpp
+++ b/app/src/libraries/crypt/Password.cpp
@@ -25,17 +25,17 @@ extern DataBaseConfig dataBaseConfig;
 
 
 Password::Password(void)
-{ 
+{
 }
 
 
 Password::~Password(void)
-{ 
+{
 }
 
 
 // Установка пароля
-// Если пароль в системе еще не использовался, пароль преобразуется в ключ 
+// Если пароль в системе еще не использовался, пароль преобразуется в ключ
 // и ключ запоминается в память
 // Если пароль в системе уже был установлен, проверяется, задан ли правильный пароль
 // путем дешифровки проверочного текста
@@ -77,7 +77,7 @@ bool Password::retrievePassword()
 
 
             // Проверяется, запомнен ли пароль в конфиге (точнее, промежуточный хеш)
-            if( mytetraConfig.getPasswordSaveFlag() and
+            if( mytetraConfig.getPasswordSaveFlag() &&
                 mytetraConfig.getPasswordMiddleHash().length()>0)
             {
                 // Пароль хранится в системе

--- a/app/src/libraries/wyedit/Editor.cpp
+++ b/app/src/libraries/wyedit/Editor.cpp
@@ -1194,6 +1194,35 @@ void Editor::keyPressEvent(QKeyEvent *event)
   if(editorToolBarAssistant->isKeyForToolLineUpdate(event))
     editorToolBarAssistant->updateToActualFormat();
 
+	if (QGuiApplication::keyboardModifiers().testFlag(Qt::ControlModifier)
+		&& event->key() == Qt::Key_Space) {
+
+		QTextCursor cursor = textArea->textCursor();
+		if (cursor.hasSelection()) {
+
+			cursor.movePosition(QTextCursor::EndOfWord
+				, QTextCursor::KeepAnchor);
+			textArea->setTextCursor(cursor);
+
+		} else {
+
+			cursor.movePosition(QTextCursor::StartOfWord);
+			cursor.movePosition(QTextCursor::EndOfWord
+				, QTextCursor::KeepAnchor);
+			textArea->setTextCursor(cursor);
+
+		}
+	} else if (QGuiApplication::keyboardModifiers().testFlag(Qt::ControlModifier)
+		&& (event->key() == Qt::Key_Return || event->key() == Qt::Key_Enter)) {
+
+		QTextCursor cursor = textArea->textCursor();
+		cursor.movePosition(QTextCursor::StartOfLine);
+		cursor.movePosition(QTextCursor::EndOfLine
+			, QTextCursor::KeepAnchor);
+		textArea->setTextCursor(cursor);
+
+	}
+
   QWidget::keyPressEvent(event);
 }
 

--- a/app/src/libraries/wyedit/EditorConfig.cpp
+++ b/app/src/libraries/wyedit/EditorConfig.cpp
@@ -1038,7 +1038,7 @@ QString EditorConfig::update_version_change_value(int versionFrom,
         }
 
     if(versionFrom==20 && versionTo==21)
-        if(name=="tools_line_1" or name=="tools_line_2")
+        if(name=="tools_line_1" || name=="tools_line_2")
         {
             if(result.contains("fontselect"))
             {
@@ -1047,7 +1047,7 @@ QString EditorConfig::update_version_change_value(int versionFrom,
         }
 
     if(versionFrom==21 && versionTo==22)
-        if(name=="tools_line_1" or name=="tools_line_2")
+        if(name=="tools_line_1" || name=="tools_line_2")
         {
             QMap<QString, QString> names;
 

--- a/app/src/libraries/wyedit/EditorShowTextDispatcher.cpp
+++ b/app/src/libraries/wyedit/EditorShowTextDispatcher.cpp
@@ -114,7 +114,7 @@ void EditorShowTextDispatcher::createWindow(const QString &noteId, int x, int y,
     editorShowText->setWindowTitle( note->getField("name") );
 
     // Установка координат окна
-    if( !(x==-1 and y==-1 and w==-1 and h==-1) )
+    if( !(x==-1 && y==-1 && w==-1 && h==-1) )
     {
         editorShowText->setGeometry(x, y, w, h);
     }

--- a/app/src/libraries/wyedit/formatters/PlacementFormatter.cpp
+++ b/app/src/libraries/wyedit/formatters/PlacementFormatter.cpp
@@ -84,6 +84,17 @@ void PlacementFormatter::onAlignrightClicked(void)
 void PlacementFormatter::onAlignwidthClicked(void)
 {
   alignText(Qt::AlignJustify);
+
+  // Создание форматирования
+  QTextBlockFormat indentFormatting;
+  //~ indentFormatting.setLeftMargin(currentIndent+deltaIndent);
+  indentFormatting.setTextIndent(24);
+
+  // Форматирование
+  textArea->textCursor().mergeBlockFormat(indentFormatting);
+
+  // editor->updateIndentsliderToActualFormat();
+  emit updateIndentsliderToActualFormat();
 }
 
 

--- a/app/src/models/appConfig/AppConfigUpdater.cpp
+++ b/app/src/models/appConfig/AppConfigUpdater.cpp
@@ -43,7 +43,7 @@ QString AppConfigUpdater::updateValueRepresentation(int versionFrom,
                                                     QString name,
                                                     QString value)
 {
-    if(versionFrom==37 and versionTo==38 and name=="dockableWindowsState")
+    if(versionFrom==37 && versionTo==38 && name=="dockableWindowsState")
     {
         if(value.trimmed().size()>1)
         {

--- a/app/src/models/shortcutSettings/ShortcutSettingsModel.cpp
+++ b/app/src/models/shortcutSettings/ShortcutSettingsModel.cpp
@@ -156,7 +156,7 @@ bool ShortcutSettingsModel::smartUpdate(updateMode mode)
 
                 // Список для сочетаний клавиш и их названий
                 static QMap<QString, QString> keysSequenceList;
-                if(i==0 and j==0)
+                if(i==0 && j==0)
                 {
                     keysSequenceList.clear();
                     duplicateError="";

--- a/app/src/views/consoleEmulator/CommandRun.cpp
+++ b/app/src/views/consoleEmulator/CommandRun.cpp
@@ -140,7 +140,7 @@ void CommandRun::removeProcessAndConsole(void)
     if(m_process)
     {
         // todo: разобраться с проблемой [WRN] QIODevice::read (QProcess): device not open
-        if(m_process->state()==QProcess::Running and m_process->processId()<=1) {
+        if(m_process->state()==QProcess::Running && m_process->processId()<=1) {
             qDebug() << QString("Abnormal execute command process PID %1 for close").arg( m_process->processId() );
         }
 
@@ -261,7 +261,7 @@ void CommandRun::onProcessFinish(int exitCode, QProcess::ExitStatus exitStatus)
     this->printOutput();
 
     // Если была какая-то ошибка
-    if( m_isError or exitCode!=0 or exitStatus==QProcess::ExitStatus::CrashExit)
+    if( m_isError || exitCode!=0 || exitStatus==QProcess::ExitStatus::CrashExit)
     {
         m_console->switchToErrorView();
 
@@ -292,7 +292,7 @@ void CommandRun::onProcessError(QProcess::ProcessError error)
 // Вывод стандартного вывода процесса в эмулятор консоли
 void CommandRun::printOutput() const
 {
-    if(!m_process or !m_console)
+    if(!m_process || !m_console)
     {
         return;
     }

--- a/app/src/views/installDialog/InstallDialog.cpp
+++ b/app/src/views/installDialog/InstallDialog.cpp
@@ -135,7 +135,7 @@ void InstallDialog::onRadioButtonPortableToggled(bool state)
 
 void InstallDialog::onAccepted()
 {
-    if( !ui->m_radioButtonStandart->isChecked() and
+    if( !ui->m_radioButtonStandart->isChecked() &&
         !ui->m_radioButtonPortable->isChecked() )
     {
         QMessageBox msgBox;

--- a/app/src/views/recordTable/RecordTableView.cpp
+++ b/app/src/views/recordTable/RecordTableView.cpp
@@ -206,7 +206,7 @@ void RecordTableView::onSelectionChanged(const QItemSelection &selected,
     // Если есть кандидат на перетаскивание записи (само перетаскивание еще не активно)
     // но мышка с него "уехала" на другую запись, и Qt пытается снять
     // выбор с кандидата на перетаскивание
-    if(startDragIndex.isValid() and startDragIndex==deselectRecord)
+    if(startDragIndex.isValid() && startDragIndex==deselectRecord)
     {
         qDebug() << "Disable select new record if drag candidate is set";
         return; // Делать програмный клик нельзя, чтобы не сбить перетаскивание, если оно начнется
@@ -584,7 +584,7 @@ void RecordTableView::mouseMoveEvent(QMouseEvent *event)
 
     // При режиме множественного выбора реакции на движение
     // мышкой быть не должно (так как работает криво), только на клики
-    if(selectionMode()==QAbstractItemView::ExtendedSelection and
+    if(selectionMode()==QAbstractItemView::ExtendedSelection &&
        this->selectionModel()->selectedRows().size()>1)
     {
         return;
@@ -594,7 +594,7 @@ void RecordTableView::mouseMoveEvent(QMouseEvent *event)
     if(isDragHappeningNow)
     {
         // При перетаскивании, Qt иногда может выделять соседние записи
-        if(startDragIndex.isValid() and startDragIndex!=this->indexAt( event->pos() ))
+        if(startDragIndex.isValid() && startDragIndex!=this->indexAt( event->pos() ))
         {
             qDebug() << "Drag detect, hold start record";
 
@@ -606,7 +606,7 @@ void RecordTableView::mouseMoveEvent(QMouseEvent *event)
     // Если при движении нажата левая кнопка мышки
     // и выделена ровно одна строка
     // (при включенном множественном выборе возможны случайные выдения и соседних строк)
-    if(event->buttons() & Qt::LeftButton and
+    if(event->buttons() & Qt::LeftButton &&
        this->selectionModel()->selectedRows().size()==1)
     {
         // Выясняется расстояние от места начала нажатия
@@ -622,7 +622,7 @@ void RecordTableView::mouseMoveEvent(QMouseEvent *event)
     // так как внутри него метасистема Qt может сгенерировать событие setSelection() и вызван слот
     // selectionChanged() с выбором соседней строки, не той на которой был клик,
     // при быстром движении мышкой
-    if( !( (event->buttons() & Qt::LeftButton) or (event->buttons() & Qt::RightButton) ) )
+    if( !( (event->buttons() & Qt::LeftButton) || (event->buttons() & Qt::RightButton) ) )
     {
         QTableView::mouseMoveEvent(event);
     }


### PR DESCRIPTION
В некоторых **if** использовались **and** и **or** вместо нормальных **&&** и **||** для C++. MSVC 2019 компилятор отказывался собирать из таких исходников.