### PR TITLE
Добавил отображение id записи и имени каталога в диалоге свойств записи

### DIFF
--- a/app/bin/resource/translations/mytetra_fr.ts
+++ b/app/bin/resource/translations/mytetra_fr.ts
@@ -1683,22 +1683,32 @@ Try to search for entire database.</source>
 <context>
     <name>InfoFieldEnter</name>
     <message>
-        <location filename="../../../src/views/record/InfoFieldEnter.cpp" line="28"/>
+        <location filename="../../../src/views/record/InfoFieldEnter.cpp" line="32"/>
+        <source>Id</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../src/views/record/InfoFieldEnter.cpp" line="40"/>
+        <source>Directory name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../src/views/record/InfoFieldEnter.cpp" line="48"/>
         <source>Title</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../src/views/record/InfoFieldEnter.cpp" line="34"/>
+        <location filename="../../../src/views/record/InfoFieldEnter.cpp" line="54"/>
         <source>Author(s)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../src/views/record/InfoFieldEnter.cpp" line="39"/>
+        <location filename="../../../src/views/record/InfoFieldEnter.cpp" line="59"/>
         <source>Url</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../src/views/record/InfoFieldEnter.cpp" line="44"/>
+        <location filename="../../../src/views/record/InfoFieldEnter.cpp" line="64"/>
         <source>Tags</source>
         <translation type="unfinished"></translation>
     </message>

--- a/app/bin/resource/translations/mytetra_ru.ts
+++ b/app/bin/resource/translations/mytetra_ru.ts
@@ -2365,22 +2365,32 @@ Try to search for entire database.</source>
 <context>
     <name>InfoFieldEnter</name>
     <message>
-        <location filename="../../../src/views/record/InfoFieldEnter.cpp" line="28"/>
+        <location filename="../../../src/views/record/InfoFieldEnter.cpp" line="32"/>
+        <source>Id</source>
+        <translation>ID</translation>
+    </message>
+    <message>
+        <location filename="../../../src/views/record/InfoFieldEnter.cpp" line="40"/>
+        <source>Directory name</source>
+        <translation>Имя директории</translation>
+    </message>
+    <message>
+        <location filename="../../../src/views/record/InfoFieldEnter.cpp" line="48"/>
         <source>Title</source>
         <translation>Название</translation>
     </message>
     <message>
-        <location filename="../../../src/views/record/InfoFieldEnter.cpp" line="34"/>
+        <location filename="../../../src/views/record/InfoFieldEnter.cpp" line="54"/>
         <source>Author(s)</source>
         <translation>Автор</translation>
     </message>
     <message>
-        <location filename="../../../src/views/record/InfoFieldEnter.cpp" line="39"/>
+        <location filename="../../../src/views/record/InfoFieldEnter.cpp" line="59"/>
         <source>Url</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../../src/views/record/InfoFieldEnter.cpp" line="44"/>
+        <location filename="../../../src/views/record/InfoFieldEnter.cpp" line="64"/>
         <source>Tags</source>
         <translation>Метки</translation>
     </message>

--- a/app/src/controllers/recordTable/RecordTableController.cpp
+++ b/app/src/controllers/recordTable/RecordTableController.cpp
@@ -697,10 +697,12 @@ void RecordTableController::editFieldContext(QModelIndex proxyIndex)
   RecordTableData *table=recordSourceModel->getTableData();
 
   // Поля окна заполняются начальными значениями
-  editRecordWin.setField("name",  table->getField("name",   pos) );
-  editRecordWin.setField("author",table->getField("author", pos) );
-  editRecordWin.setField("url",   table->getField("url",    pos) );
-  editRecordWin.setField("tags",  table->getField("tags",   pos) );
+  editRecordWin.setField("id",     table->getField("id",     pos) );
+  editRecordWin.setField("dir",    table->getField("dir",    pos) );
+  editRecordWin.setField("name",   table->getField("name",   pos) );
+  editRecordWin.setField("author", table->getField("author", pos) );
+  editRecordWin.setField("url",    table->getField("url",    pos) );
+  editRecordWin.setField("tags",   table->getField("tags",   pos) );
 
   // Если запись заблокирована
   if(table->getField("block",   pos)=="1")

--- a/app/src/views/record/AddNewRecord.cpp
+++ b/app/src/views/record/AddNewRecord.cpp
@@ -47,6 +47,9 @@ void AddNewRecord::setupUI(void)
 {
   this->setWindowTitle(tr("Enter a new note"));
 
+  // Виджет ввода инфополей
+  infoField.setDisplayOnlyEditableFields(true);
+
   // Редактор текста записи
   recordTextEditor.initEnableAssembly(true);
   recordTextEditor.initConfigFileName(globalParameters.getWorkDirectory()+"/editorconf.ini");

--- a/app/src/views/record/InfoFieldEnter.cpp
+++ b/app/src/views/record/InfoFieldEnter.cpp
@@ -86,6 +86,8 @@ void InfoFieldEnter::setup_ui(void)
    expandInfo->setIcon(QIcon(":/resource/pic/triangl_up.svg"));
    // expandInfo->setIcon(this->style()->standardIcon(QStyle::SP_ArrowUp));
   }
+
+  updateReadOnlyFieldsVisibility();
 }
 
 
@@ -159,11 +161,12 @@ void InfoFieldEnter::expandInfoOnDisplay(QString expand)
  recordTagsLabel->setVisible(i);
  recordTags->setVisible(i);
 
- recordIdLabel->setVisible(i);
- recordId->setVisible(i);
+ bool isDisplayReadOnlyFields = i && !isDisplayOnlyEditableFields;
+ recordIdLabel->setVisible(isDisplayReadOnlyFields);
+ recordId->setVisible(isDisplayReadOnlyFields);
 
- dirNameLabel->setVisible(i);
- dirName->setVisible(i);
+ dirNameLabel->setVisible(isDisplayReadOnlyFields);
+ dirName->setVisible(isDisplayReadOnlyFields);
 }
 
 
@@ -255,4 +258,23 @@ void InfoFieldEnter::setReadOnly(bool state)
 bool InfoFieldEnter::isReadOnly()
 {
   return recordName->isReadOnly();
+}
+
+
+void InfoFieldEnter::setDisplayOnlyEditableFields(bool value)
+{
+  isDisplayOnlyEditableFields = value;
+
+  updateReadOnlyFieldsVisibility();
+}
+
+void InfoFieldEnter::updateReadOnlyFieldsVisibility()
+{
+  bool isVisible = !isDisplayOnlyEditableFields;
+
+  recordIdLabel->setVisible(isVisible);
+  recordId->setVisible(isVisible);
+
+  dirNameLabel->setVisible(isVisible);
+  dirName->setVisible(isVisible);
 }

--- a/app/src/views/record/InfoFieldEnter.cpp
+++ b/app/src/views/record/InfoFieldEnter.cpp
@@ -24,6 +24,25 @@ InfoFieldEnter::~InfoFieldEnter()
 
 void InfoFieldEnter::setup_ui(void)
 {
+ QPalette bgPalette = this->palette();
+ bgPalette.setColor(QPalette::Base, bgPalette.color(QPalette::Background));
+
+ // Элементы для отображения id записи
+ recordIdLabel=new QLabel(this);
+ recordIdLabel->setText(tr("Id"));
+ recordId=new QLineEdit(this);
+ recordId->setMinimumWidth(500);
+ recordId->setReadOnly(true);
+ recordId->setPalette(bgPalette);
+
+ // Элементы для отображения названия каталога
+ dirNameLabel=new QLabel(this);
+ dirNameLabel->setText(tr("Directory name"));
+ dirName=new QLineEdit(this);
+ dirName->setMinimumWidth(500);
+ dirName->setReadOnly(true);
+ dirName->setPalette(bgPalette);
+
  // Элементы для запроса названия записи
  recordNameLabel=new QLabel(this);
  recordNameLabel->setText(tr("Title"));
@@ -100,6 +119,12 @@ void InfoFieldEnter::assembly(void)
  infoFieldLayout->addWidget(recordTagsLabel,++y,0);
  infoFieldLayout->addWidget(recordTags,y,1);
 
+ infoFieldLayout->addWidget(recordIdLabel,++y,0);
+ infoFieldLayout->addWidget(recordId,y,1);
+
+ infoFieldLayout->addWidget(dirNameLabel,++y,0);
+ infoFieldLayout->addWidget(dirName,y,1);
+
  // Устанавливается видимость или невидимость полей author, url, tags...
  expandInfoOnDisplay( mytetraConfig.get_addnewrecord_expand_info() );
 
@@ -133,6 +158,12 @@ void InfoFieldEnter::expandInfoOnDisplay(QString expand)
 
  recordTagsLabel->setVisible(i);
  recordTags->setVisible(i);
+
+ recordIdLabel->setVisible(i);
+ recordId->setVisible(i);
+
+ dirNameLabel->setVisible(i);
+ dirName->setVisible(i);
 }
 
 
@@ -171,7 +202,9 @@ bool InfoFieldEnter::checkFieldName(QString name)
  if(name=="name" ||
     name=="author" ||
     name=="url" ||
-    name=="tags")
+    name=="tags" ||
+    name=="id" ||
+    name=="dir")
   return true;
  else
   return false;
@@ -198,6 +231,8 @@ void InfoFieldEnter::setField(QString name,QString value)
 {
  if(checkFieldName(name))
   {
+   if(name=="id")  recordId->setText(value);
+   if(name=="dir")  dirName->setText(value);
    if(name=="name")  recordName->setText(value);
    if(name=="author")recordAuthor->setText(value);
    if(name=="url")   recordUrl->setText(value);

--- a/app/src/views/record/InfoFieldEnter.h
+++ b/app/src/views/record/InfoFieldEnter.h
@@ -30,11 +30,15 @@ public:
   void setReadOnly(bool state);
   bool isReadOnly();
 
+  void setDisplayOnlyEditableFields(bool value);
+
 public slots:
 
   void expandInfoClick(void);
 
 private:
+
+  bool isDisplayOnlyEditableFields;
 
   // Id записи
   QLabel    *recordIdLabel;
@@ -71,6 +75,7 @@ private:
   void assembly(void);
 
   void expandInfoOnDisplay(QString expand);
+  void updateReadOnlyFieldsVisibility();
 
 };
 

--- a/app/src/views/record/InfoFieldEnter.h
+++ b/app/src/views/record/InfoFieldEnter.h
@@ -36,6 +36,14 @@ public slots:
 
 private:
 
+  // Id записи
+  QLabel    *recordIdLabel;
+  QLineEdit *recordId;
+
+  // Название каталога
+  QLabel    *dirNameLabel;
+  QLineEdit *dirName;
+
   // Ввод названия записи
   QLabel    *recordNameLabel;
   QLineEdit *recordName;


### PR DESCRIPTION
Вывел поля с id заметки и именем каталога на форму только для чтения:   
![image](https://github.com/user-attachments/assets/e50e5449-9c6f-47cf-a6f9-bf73772ed38b)  
![image](https://github.com/user-attachments/assets/fa3023d3-a6fc-4dab-928a-4444383e08f2)   
Плюс добавил заголовки полей в файл перевода на русский (там кстати довольно много собралось непереведенного текста, позже возможно создам PR).

Узнать имя каталога записи иногда приходится при конфликтах синхронизации базы (например через Syncthing). Поле с id записи вынес за компанию.

Эти поля раньше можно было увидеть в UI только в таблице записей ветки. Но оттуда нельзя скопировать их значения, да и смотреть неудобно, все столбцы обычно не влазят на экран. Тогда приходилось лезть в mytetra.xml и искать вручную.  