### PR TITLE
Альфа канал в диалоге выбора цвета

### DIFF
--- a/app/bin/resource/translations/mytetra_ru.ts
+++ b/app/bin/resource/translations/mytetra_ru.ts
@@ -4755,7 +4755,7 @@ Please select single item for enabling edit operation.</source>
     <message>
         <location filename="../../../src/libraries/wyedit/formatters/TypefaceFormatter.cpp" line="1266"/>
         <source>Select text color</source>
-        <translation>Выбор цвта текста</translation>
+        <translation>Выбор цвета текста</translation>
     </message>
     <message>
         <location filename="../../../src/libraries/wyedit/formatters/TypefaceFormatter.cpp" line="1496"/>

--- a/app/src/libraries/wyedit/EditorConfigFont.cpp
+++ b/app/src/libraries/wyedit/EditorConfigFont.cpp
@@ -219,7 +219,7 @@ void EditorConfigFont::on_code_select_color_button_click()
  QColor color(conf->get_code_font_color());
 
  // Диалог запроса цвета
- QColor selectedColor=QColorDialog::getColor(color, this);
+ QColor selectedColor=QColorDialog::getColor(color, this, QString(), QColorDialog::ShowAlphaChannel);
 
  // Если цвет выбран, и он правильный
  if(selectedColor.isValid())

--- a/app/src/libraries/wyedit/EditorTablePropertiesForm.cpp
+++ b/app/src/libraries/wyedit/EditorTablePropertiesForm.cpp
@@ -193,7 +193,7 @@ void EditorTablePropertiesForm::setColorForButtonBackgroundColor(QColor iColor)
 void EditorTablePropertiesForm::onClickedButtonBackgroundColor()
 {
   // Диалог запроса цвета (доработать)
-  QColor selectedColor=QColorDialog::getColor(backgroundColor, this);
+  QColor selectedColor=QColorDialog::getColor(backgroundColor, this, QString(), QColorDialog::ShowAlphaChannel);
 
   // Если цвет выбран, и он правильный
   if(selectedColor.isValid())

--- a/app/src/libraries/wyedit/formatters/TypefaceFormatter.cpp
+++ b/app/src/libraries/wyedit/formatters/TypefaceFormatter.cpp
@@ -1269,7 +1269,7 @@ void TypefaceFormatter::onFontcolorClicked()
         currentColor = textArea->palette().windowText().color();
 
     // Диалог запроса цвета текста
-    QColor selectedColor = QColorDialog::getColor(currentColor, editor, tr("Select text color"));
+    QColor selectedColor = QColorDialog::getColor(currentColor, editor, tr("Select text color"), QColorDialog::ShowAlphaChannel);
 
     // Если цвет выбран, и он правильный
     if(selectedColor.isValid())
@@ -1499,7 +1499,7 @@ void TypefaceFormatter::onBackgroundcolorClicked()
     }
 
     // Диалог запроса цвета фона
-    QColor selectedColor = QColorDialog::getColor(currentColor, editor, tr("Select background color"));
+    QColor selectedColor = QColorDialog::getColor(currentColor, editor, tr("Select background color"), QColorDialog::ShowAlphaChannel);
 
     // Если цвет выбран, и он правильный
     if(selectedColor.isValid())

--- a/app/src/views/appConfigWindow/AppConfigPage_Attach.cpp
+++ b/app/src/views/appConfigWindow/AppConfigPage_Attach.cpp
@@ -102,7 +102,7 @@ void AppConfigPage_Attach::onEnableRecordWithAttachHighlight(bool state)
 void AppConfigPage_Attach::onClickedHighlightColor()
 {
     // Диалог запроса цвета
-    QColor selectedColor=QColorDialog::getColor( *highlightColor, this );
+    QColor selectedColor=QColorDialog::getColor( *highlightColor, this, QString(), QColorDialog::ShowAlphaChannel);
 
     // Если цвет выбран, и он правильный
     if(selectedColor.isValid())


### PR DESCRIPTION
1) В диалоги выбора цвета добавил возможность установки альфа канала

![image](https://github.com/user-attachments/assets/099d1483-d405-4e1e-ad5c-9886fdfb470e)

2) Также исправил заголовок диалога "Выбор цвета текста".